### PR TITLE
Internal: Fixes for a number of bugs

### DIFF
--- a/pkg/database/segment.go
+++ b/pkg/database/segment.go
@@ -32,10 +32,6 @@ func (s *Segment) Append(d Datum) (bool, error) {
 		return false, errors.New("cannot add additional elements, segment at maximum size")
 	}
 
-	if s.Size == 0 {
-		s.HeadTime = time.Now()
-	}
-
 	if d.Delta == -1 {
 		d.Delta = time.Now().Sub(s.HeadTime)
 	}


### PR DESCRIPTION
This commit fixes a number of bugs:

   * Topics weren't being written out to the write-ahead-log, which means we'd lose the ability to decode topics between restarts of the database.
   * The initial segment was never being written out to the write-ahead-log, which meant that all timestamps would be wildly incorrect for that segment.

This resolves issue #30 