### PR TITLE
Fix a bug where sample may not work if large gaps in the data exists.

### DIFF
--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -97,7 +97,7 @@ func (q QuantifierNode) GenerateFilter(db *database.Database) database.Filter {
 			for _, val := range data {
 				if val.Time.After(nextTime) || val.Time.Equal(nextTime) {
 					filtered = append(filtered, val)
-					nextTime = nextTime.Add(sampleDuration)
+					nextTime = val.Time.Add(sampleDuration)
 				}
 			}
 


### PR DESCRIPTION
Since we were repeatedly incrementing the same time.Time struct, if we had a large gap in data, you could end up in the situation where you get multiple samples from within the same sample period. Instead, let's always increment the last matched time.Time struct.