### PR TITLE
Fix a couple of papercuts with `fossil client`

### DIFF
--- a/cmd/fossil/client/client.go
+++ b/cmd/fossil/client/client.go
@@ -111,10 +111,4 @@ func clientPrompt(c net.Conn) {
 	}
 }
 
-func init() {
-	// Flags for this command
-	// Command.Flags().StringP("host", "H", "fossil://local/default", "Host to send the messages")
-
-	// Bind flags to viper
-	// viper.BindPFlag("host", Command.Flags().Lookup("host"))
-}
+func init() {}

--- a/cmd/fossil/client/client.go
+++ b/cmd/fossil/client/client.go
@@ -86,6 +86,11 @@ func clientPrompt(c net.Conn) {
 			fmt.Printf("Err: unable to read input\n\t'%s'\n", string(line))
 		}
 
+		if strings.HasPrefix(string(line), "QUIT") {
+			fmt.Println("bye!")
+			return
+		}
+
 		err = send(c, line)
 		if err != nil {
 			fmt.Printf("Err: unable to send command\n\t'%s'\n", err)


### PR DESCRIPTION
* Introduce a `QUIT` pseudo-command
* Ensure that the client is well-behaved when piping data into the command

For example, things like this now work nicely:

```
λ › echo "QUERY all" | ./fossil client -H fossil://localhost:8001                                                                                    Projects/fossil dev/client-papercuts
2022-11-29 16:07:43.458014923 -0800 PST	/	foo
2022-11-29 16:08:06.661906812 -0800 PST	/	foo
2022-11-29 16:08:09.736406357 -0800 PST	/	foo
2022-11-29 16:08:11.121007235 -0800 PST	/	foo
2022-11-29 16:08:56.432017214 -0800 PST	/	foo
2022-11-29 17:33:55.837350118 -0800 PST	/	bar
2022-11-29 17:35:31.820416142 -0800 PST	/	thisiscool!
2022-11-29 20:00:49.934418272 -0800 PST	/	wow
2022-11-29 20:00:56.678709179 -0800 PST	/	such fun
2022-11-29 22:52:53.990040897 -0800 PST	/	1
2022-11-29 22:53:31.164377092 -0800 PST	/	1
2022-11-29 22:59:45.410514736 -0800 PST	/	1
2022-11-29 22:59:54.222332738 -0800 PST	/	1
2022-11-29 23:00:31.373620826 -0800 PST	/	1
2022-11-29 23:00:31.374257809 -0800 PST	/	2
2022-11-29 23:00:31.374610623 -0800 PST	/	3
2022-11-29 23:01:43.933599562 -0800 PST	/	1
2022-11-29 23:01:43.934034573 -0800 PST	/	2
2022-11-29 23:01:43.934334215 -0800 PST	/	3
2022-11-29 23:01:51.260166339 -0800 PST	/	1
2022-11-29 23:01:51.260629323 -0800 PST	/	2
2022-11-29 23:01:51.2609552 -0800 PST	/	3
2022-11-29 23:02:42.33789013 -0800 PST	/	1
2022-11-29 23:02:42.338174539 -0800 PST	/	2
2022-11-29 23:02:42.338489604 -0800 PST	/	3
2022-11-29 23:02:47.80114312 -0800 PST	/	1
2022-11-29 23:02:47.801578146 -0800 PST	/	2
2022-11-29 23:02:47.801887999 -0800 PST	/	3
2022-11-29 23:02:52.50129596 -0800 PST	/	1
2022-11-29 23:02:52.501807909 -0800 PST	/	2
2022-11-29 23:02:52.502231682 -0800 PST	/	3

λ ›
```