### PR TITLE
Refactor configuration loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 wal.log
+data/

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ local = true
 verbose = 2
 
 [database]
-directory = "data/default"
+directory = "/mnt/e/data"
 
 [database.test]
-directory = "data/mydata"
+directory = "./data"
 
 [database.tester]
 ```
@@ -100,6 +100,8 @@ will automatically have the directory set to `./data/tester` as the location to
 store the data for that logical database, where as the `database.test` block
 has configured its data directory as `data/mydata`.
 
-| Option               | Default           | Description                                                       |
-| -------------------- | ----------------- | ----------------------------------------------------------------- |
-| `database.directory` | `"./data/<name>"` | Directory the sever uses to store the data for a logical database |
+**Note:** If the only database directory set in the config file is on the default block, all databases will be created in that directory.
+
+| Option               | Default      | Description                                                       |
+| -------------------- | ------------ | ----------------------------------------------------------------- |
+| `database.directory` | `"./<name>"` | Directory the sever uses to store the data for a logical database |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ directory = "data/mydata"
 #### Root `fossil` config block
 | Option             | Default                    | Description                                            |
 | ------------------ | -------------------------- | ------------------------------------------------------ |
-| `fossil.port`      | 8000                       | Port fossil server listens on                          |
+| `fossil.port`      | 8001                       | Port fossil server listens on                          |
 | `fossil.prom-port` | 2112                       | Port fossil server servers `/metrics` on               |
 | `fossil.verbose`   | 0                          | Configures the log level [0: info, 1: debug, 2: trace] |
 | `fossil.host`      | `"fossil://local/default"` | Connection string client will connect to               |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 A small, efficient time-series database. See [Overview](./docs/overview.md) for a high-level overview on current design.
 
+- [Fossil](#fossil)
+  - [Overview](#overview)
+    - [Use Cases](#use-cases)
+  - [How to](#how-to)
+    - [Install](#install)
+    - [Usage](#usage)
+    - [Config](#config)
+      - [Root `fossil` config block](#root-fossil-config-block)
+      - [`database` config block](#database-config-block)
+
+
 ## Overview
 
 Fossil is intended to be simple enough to use as a local time-series database (similar to a SQLite database) and robust
@@ -17,3 +28,78 @@ Fossil solves the following use cases:
 - Local Time Series Database that stores data in a local DB file
 - Collect data over a TCP connection in fire and forget mode
 - Query data over a TCP connection
+
+## How to
+
+### Install
+```shell
+go install github.com/dburkart/fossil
+```
+or
+```shell
+git clone https://github.com/dburkart/fossil.git
+cd fossil
+go run main.go
+```
+
+### Usage
+```shell
+> fossil server -h
+Database for collecting and querying metrics
+
+Usage:
+  fossil server [flags]
+
+Flags:
+  -d, --database string   Path to store database files (default "./")
+  -h, --help              help for server
+  -p, --port int          Database server port for data collection (default 8001)
+      --prom-http int     Set the port for /metrics is bound to (default 2112)
+
+Global Flags:
+  -c, --config string   Path to the fossil config file (default "./config.toml")
+  -H, --host string     Host to send the messages (default "fossil://local/default")
+      --local           Configures the logger to print readable logs (default true)
+  -v, --verbose count   -v for debug logs (-vv for trace)
+```
+
+### Config
+```toml
+[fossil]
+port = 8000
+prom-port = 2112
+
+host = "fossil://local/default"
+local = true
+verbose = 2
+
+[database]
+directory = "data/default"
+
+[database.test]
+directory = "data/mydata"
+
+[database.tester]
+```
+
+#### Root `fossil` config block
+| Option             | Default                    | Description                                            |
+| ------------------ | -------------------------- | ------------------------------------------------------ |
+| `fossil.port`      | 8000                       | Port fossil server listens on                          |
+| `fossil.prom-port` | 2112                       | Port fossil server servers `/metrics` on               |
+| `fossil.verbose`   | 0                          | Configures the log level [0: info, 1: debug, 2: trace] |
+| `fossil.host`      | `"fossil://local/default"` | Connection string client will connect to               |
+| `fossil.local`     | true                       | Configures output logs to be in plaintext              |
+
+####  `database` config block
+The first database block without a `.<name>` applies to the `default` database. 
+Any database block that contains a name identifier will configure the server 
+to create a database with that name and configure it with the options contained
+in the block. For example, the `database.tester` block in the toml config above
+will automatically have the directory set to `./data/tester` as the location to
+store the data for that logical database, where as the `database.test` block
+has configured its data directory as `data/mydata`.
+
+| Option               | Default           | Description                                                       |
+| -------------------- | ----------------- | ----------------------------------------------------------------- |
+| `database.directory` | `"./data/<name>"` | Directory the sever uses to store the data for a logical database |

--- a/README.md
+++ b/README.md
@@ -102,6 +102,6 @@ has configured its data directory as `data/mydata`.
 
 **Note:** If the only database directory set in the config file is on the default block, all databases will be created in that directory.
 
-| Option               | Default      | Description                                                       |
-| -------------------- | ------------ | ----------------------------------------------------------------- |
-| `database.directory` | `"./<name>"` | Directory the sever uses to store the data for a logical database |
+| Option               | Default | Description                                                                                   |
+| -------------------- | ------- | --------------------------------------------------------------------------------------------- |
+| `database.directory` | `"./"`  | Directory the sever uses to store the data for a logical database. This directory must exist. |

--- a/cmd/fossil/client/client.go
+++ b/cmd/fossil/client/client.go
@@ -34,7 +34,10 @@ var Command = &cobra.Command{
 		target := proto.ParseConnectionString(host)
 
 		if target.Local {
-			db := database.NewDatabase(target.Database)
+			db, err := database.NewDatabase(log, target.Database, target.Database)
+			if err != nil {
+				log.Fatal().Err(err).Msg("error creating new database")
+			}
 
 			localPrompt(db)
 		} else {

--- a/cmd/fossil/client/client.go
+++ b/cmd/fossil/client/client.go
@@ -10,6 +10,10 @@ package client
 import (
 	"bufio"
 	"fmt"
+	"net"
+	"os"
+	"strings"
+
 	"github.com/dburkart/fossil/pkg/database"
 	"github.com/dburkart/fossil/pkg/proto"
 	"github.com/dburkart/fossil/pkg/query"
@@ -17,9 +21,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"net"
-	"os"
-	"strings"
 )
 
 var Command = &cobra.Command{
@@ -29,7 +30,7 @@ var Command = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log := viper.Get("logger").(zerolog.Logger)
 
-		host := viper.GetString("host")
+		host := viper.GetString("fossil.host")
 		target := proto.ParseConnectionString(host)
 
 		if target.Local {

--- a/cmd/fossil/config.go
+++ b/cmd/fossil/config.go
@@ -24,6 +24,7 @@ func initConfig(configFile string) {
 	viper.SetConfigType("toml")
 	viper.AddConfigPath("config")
 	viper.AddConfigPath("/etc/fossil/")
+	viper.AddConfigPath("/usr/local/etc/fossil/")
 	viper.AddConfigPath("$HOME/.fossil")
 	viper.AddConfigPath(".")
 	viper.SetConfigFile(configFile)

--- a/cmd/fossil/config.go
+++ b/cmd/fossil/config.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022, Gideon Williams <gideon@gideonw.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+package fossil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
+)
+
+func initConfig(configFile string) {
+	log := viper.Get("logger").(zerolog.Logger)
+
+	// config Read
+	viper.SetConfigType("toml")
+	viper.AddConfigPath("config")
+	viper.AddConfigPath("/etc/fossil/")
+	viper.AddConfigPath("$HOME/.fossil")
+	viper.AddConfigPath(".")
+	viper.SetConfigFile(configFile)
+
+	err := viper.ReadInConfig()
+	if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+		log.Info().Msg("No config file found, using defaults as a base")
+	} else if err != nil {
+		log.Error().Msg("Error loading config file")
+	}
+
+	databaseConfigs := viper.GetStringMap("database")
+	databases := []string{}
+
+	// Range over the database blocks to set a list of database names
+	for k, v := range databaseConfigs {
+		// Root fossil database blocks
+		if t := reflect.ValueOf(v); t.Kind() == reflect.Map {
+			databases = append(databases, k)
+			for dbk, dbv := range v.(map[string]interface{}) {
+				log.Trace().Msgf("database.%s.%s = %v", k, dbk, dbv)
+				viper.Set(fmt.Sprintf("database.%s.%s", k, dbk), dbv)
+			}
+		} else {
+			log.Trace().Msgf("database.default.%s = %v", k, v)
+			viper.Set(fmt.Sprintf("database.default.%s", k), v)
+		}
+	}
+	if len(databases) < len(databaseConfigs) || len(databases) == 0 {
+		databases = append(databases, "default")
+	}
+
+	viper.Set("database", "")
+	viper.Set("database.names", databases)
+}
+
+func initLogLevel() {
+	level := viper.GetInt("fossil.verbose")
+	switch clamp(2, level) {
+	case 2:
+		zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	case 1:
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	default:
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	}
+}
+
+func initLogging() {
+	var writer io.Writer
+
+	writer = os.Stderr
+	if viper.GetBool("fossil.local") {
+		writer = zerolog.ConsoleWriter{
+			Out:        os.Stdout,
+			TimeFormat: time.RFC3339,
+		}
+	}
+
+	logger := zerolog.New(writer).
+		With().
+		Timestamp().
+		Caller().
+		Logger()
+
+	viper.Set("logger", logger)
+}
+
+func traceConfig() {
+	log := viper.Get("logger").(zerolog.Logger)
+
+	for _, v := range viper.AllKeys() {
+		if v == "logger" {
+			continue
+		}
+		log.Trace().Msgf("%s=%v", v, viper.Get(v))
+	}
+}
+
+func clamp(clamp, a int) int {
+	if a >= clamp {
+		return clamp
+	}
+	return a
+}

--- a/cmd/fossil/root.go
+++ b/cmd/fossil/root.go
@@ -30,15 +30,15 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	// Configure the root binary options
-	rootCmd.PersistentFlags().CountP("fossil.verbose", "v", "-v for debug logs (-vv for trace)")
-	rootCmd.PersistentFlags().Bool("fossil.local", true, "Configures the logger to print readable logs") //TODO: true until we have a config file format
-	rootCmd.PersistentFlags().StringP("fossil.host", "H", "fossil://local/default", "Host to send the messages")
+	rootCmd.PersistentFlags().CountP("verbose", "v", "-v for debug logs (-vv for trace)")
+	rootCmd.PersistentFlags().Bool("local", true, "Configures the logger to print readable logs") //TODO: true until we have a config file format
+	rootCmd.PersistentFlags().StringP("host", "H", "fossil://local/default", "Host to send the messages")
 	rootCmd.PersistentFlags().StringP("config", "c", "./config.toml", "Path to the fossil config file")
 
 	// Bind viper config to the root flags
-	viper.BindPFlag("fossil.local", rootCmd.PersistentFlags().Lookup("fossil.local"))
-	viper.BindPFlag("fossil.verbose", rootCmd.PersistentFlags().Lookup("fossil.verbose"))
-	viper.BindPFlag("fossil.host", rootCmd.PersistentFlags().Lookup("fossil.host"))
+	viper.BindPFlag("fossil.local", rootCmd.PersistentFlags().Lookup("local"))
+	viper.BindPFlag("fossil.verbose", rootCmd.PersistentFlags().Lookup("verbose"))
+	viper.BindPFlag("fossil.host", rootCmd.PersistentFlags().Lookup("host"))
 	viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
 
 	// Bind viper flags to ENV variables

--- a/cmd/fossil/server/server.go
+++ b/cmd/fossil/server/server.go
@@ -23,9 +23,8 @@ var Command = &cobra.Command{
 		// Initialize database server
 		srv := server.New(
 			logger,
-			viper.GetString("database"),
-			viper.GetInt("collection-port"),
-			viper.GetInt("database-port"),
+			viper.GetString("database.path"),
+			viper.GetInt("port"),
 			viper.GetInt("prom-http"),
 		)
 
@@ -39,14 +38,12 @@ var Command = &cobra.Command{
 
 func init() {
 	// Flags for this command
-	Command.Flags().IntP("collection-port", "c", 8001, "Database server port for data collection")
-	Command.Flags().IntP("database-port", "p", 8000, "Database server port for client connections")
+	Command.Flags().IntP("port", "c", 8001, "Database server port for data collection")
 	Command.Flags().Int("prom-http", 2112, "Set the port for /metrics is bound to")
 	Command.Flags().StringP("database", "d", "./", "Path to store database files")
 
 	// Bind flags to viper
-	viper.BindPFlag("collection-port", Command.Flags().Lookup("collection-port"))
-	viper.BindPFlag("database-port", Command.Flags().Lookup("database-port"))
-	viper.BindPFlag("prom-http", Command.Flags().Lookup("prom-http"))
-	viper.BindPFlag("database", Command.Flags().Lookup("database"))
+	viper.BindPFlag("fossil.port", Command.Flags().Lookup("port"))
+	viper.BindPFlag("fossil.prom-port", Command.Flags().Lookup("prom-http"))
+	viper.BindPFlag("database.path", Command.Flags().Lookup("database"))
 }

--- a/cmd/fossil/server/server.go
+++ b/cmd/fossil/server/server.go
@@ -7,6 +7,10 @@
 package server
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/dburkart/fossil/pkg/server"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -20,10 +24,15 @@ var Command = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := viper.Get("logger").(zerolog.Logger)
 
+		configs, err := buildDatabaseConfigs()
+		if err != nil {
+			panic(err)
+		}
+
 		// Initialize database server
 		srv := server.New(
 			logger,
-			viper.GetString("database.directory"),
+			configs,
 			viper.GetInt("fossil.port"),
 			viper.GetInt("fossil.prom-http"),
 		)
@@ -34,6 +43,41 @@ var Command = &cobra.Command{
 		// Serve the metrics endpoint
 		srv.ServeMetrics()
 	},
+}
+
+func buildDatabaseConfigs() (map[string]server.DatabaseConfig, error) {
+	ret := make(map[string]server.DatabaseConfig)
+
+	for _, v := range viper.GetStringSlice("database.names") {
+		// If this is a non-default db look up the config value for it
+		dbConfig := server.DatabaseConfig{
+			Name:      v,
+			Directory: filepath.Clean(viper.GetString(strings.Join([]string{"database", v, "directory"}, "."))),
+		}
+
+		// If this is the default, use the [database] block value
+		if v == "default" {
+			dbConfig.Directory = filepath.Clean(viper.GetString("database.directory"))
+		}
+
+		ret[v] = dbConfig
+	}
+
+	// After the config has been loaded, any database block without a value receives the default directory
+	for k, v := range ret {
+		// Do not modify default at this point
+		if k == "default" {
+			continue
+		}
+		// Set the db directory to `defaultpath/name`
+		if v.Directory == "" {
+			v.Directory = filepath.Join(ret["default"].Directory, v.Name)
+			ret[k] = v
+		}
+	}
+	fmt.Printf("%#v\n", ret)
+
+	return ret, nil
 }
 
 func init() {

--- a/cmd/fossil/server/server.go
+++ b/cmd/fossil/server/server.go
@@ -38,7 +38,7 @@ var Command = &cobra.Command{
 
 func init() {
 	// Flags for this command
-	Command.Flags().IntP("port", "c", 8001, "Database server port for data collection")
+	Command.Flags().IntP("port", "p", 8001, "Database server port for data collection")
 	Command.Flags().Int("prom-http", 2112, "Set the port for /metrics is bound to")
 	Command.Flags().StringP("database", "d", "./", "Path to store database files")
 

--- a/cmd/fossil/server/server.go
+++ b/cmd/fossil/server/server.go
@@ -24,8 +24,8 @@ var Command = &cobra.Command{
 		srv := server.New(
 			logger,
 			viper.GetString("database.path"),
-			viper.GetInt("port"),
-			viper.GetInt("prom-http"),
+			viper.GetInt("fossil.port"),
+			viper.GetInt("fossil.prom-http"),
 		)
 
 		// Serve the database

--- a/cmd/fossil/server/server.go
+++ b/cmd/fossil/server/server.go
@@ -23,7 +23,7 @@ var Command = &cobra.Command{
 		// Initialize database server
 		srv := server.New(
 			logger,
-			viper.GetString("database.path"),
+			viper.GetString("database.directory"),
 			viper.GetInt("fossil.port"),
 			viper.GetInt("fossil.prom-http"),
 		)
@@ -45,5 +45,5 @@ func init() {
 	// Bind flags to viper
 	viper.BindPFlag("fossil.port", Command.Flags().Lookup("port"))
 	viper.BindPFlag("fossil.prom-port", Command.Flags().Lookup("prom-http"))
-	viper.BindPFlag("database.path", Command.Flags().Lookup("database"))
+	viper.BindPFlag("database.directory", Command.Flags().Lookup("database"))
 }

--- a/cmd/fossil/server/server.go
+++ b/cmd/fossil/server/server.go
@@ -23,15 +23,10 @@ var Command = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := viper.Get("logger").(zerolog.Logger)
 
-		configs, err := buildDatabaseConfigs()
-		if err != nil {
-			panic(err)
-		}
-
 		// Initialize database server
 		srv := server.New(
 			logger,
-			configs,
+			buildDatabaseConfigs(),
 			viper.GetInt("fossil.port"),
 			viper.GetInt("fossil.prom-http"),
 		)
@@ -44,7 +39,7 @@ var Command = &cobra.Command{
 	},
 }
 
-func buildDatabaseConfigs() (map[string]server.DatabaseConfig, error) {
+func buildDatabaseConfigs() map[string]server.DatabaseConfig {
 	ret := make(map[string]server.DatabaseConfig)
 
 	for _, v := range viper.GetStringSlice("database.names") {
@@ -72,7 +67,7 @@ func buildDatabaseConfigs() (map[string]server.DatabaseConfig, error) {
 		ret[k] = v
 	}
 
-	return ret, nil
+	return ret
 }
 
 func init() {

--- a/cmd/fossil/server/server.go
+++ b/cmd/fossil/server/server.go
@@ -7,7 +7,6 @@
 package server
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -52,7 +51,7 @@ func buildDatabaseConfigs() (map[string]server.DatabaseConfig, error) {
 		// If this is a non-default db look up the config value for it
 		dbConfig := server.DatabaseConfig{
 			Name:      v,
-			Directory: filepath.Clean(viper.GetString(strings.Join([]string{"database", v, "directory"}, "."))),
+			Directory: viper.GetString(strings.Join([]string{"database", v, "directory"}, ".")),
 		}
 
 		// If this is the default, use the [database] block value
@@ -65,17 +64,13 @@ func buildDatabaseConfigs() (map[string]server.DatabaseConfig, error) {
 
 	// After the config has been loaded, any database block without a value receives the default directory
 	for k, v := range ret {
-		// Do not modify default at this point
-		if k == "default" {
-			continue
-		}
-		// Set the db directory to `defaultpath/name`
+		// Set the db directory to `defaultpath`
 		if v.Directory == "" {
-			v.Directory = filepath.Join(ret["default"].Directory, v.Name)
-			ret[k] = v
+			v.Directory = ret["default"].Directory
 		}
+		v.Directory = filepath.Clean(v.Directory)
+		ret[k] = v
 	}
-	fmt.Printf("%#v\n", ret)
 
 	return ret, nil
 }

--- a/cmd/fossil/test/test.go
+++ b/cmd/fossil/test/test.go
@@ -21,7 +21,7 @@ var Command = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log := viper.Get("logger").(zerolog.Logger)
 
-		host := viper.GetString("host")
+		host := viper.GetString("fossil.host")
 		c, err := net.Dial("tcp4", host)
 		if err != nil {
 			log.Error().Err(err).Str("host", host).Msg("unable to connect to server")

--- a/config.default.toml
+++ b/config.default.toml
@@ -1,5 +1,5 @@
 [fossil]
-port = 8000
+port = 8001
 prom-port = 2112
 
 host = "fossil://local/default"

--- a/config.default.toml
+++ b/config.default.toml
@@ -7,9 +7,9 @@ local = true
 verbose = 2
 
 [database]
-directory = "data/default"
+directory = "./data"
 
 [database.test]
-directory = "data/test"
+directory = "./data/testme"
 
 [database.tester]

--- a/config.default.toml
+++ b/config.default.toml
@@ -10,6 +10,6 @@ verbose = 2
 directory = "./data"
 
 [database.test]
-directory = "./data/testme"
+directory = "./data2"
 
 [database.tester]

--- a/config.default.toml
+++ b/config.default.toml
@@ -7,9 +7,9 @@ local = true
 verbose = 2
 
 [database]
-path = "data/default.log"
+directory = "data/default"
 
 [database.test]
-path = "data/test.log"
+directory = "data/test"
 
 [database.tester]

--- a/config.default.toml
+++ b/config.default.toml
@@ -1,0 +1,15 @@
+[fossil]
+port = 8000
+prom-port = 2112
+
+host = "fossil://local/default"
+local = true
+verbose = 2
+
+[database]
+path = "data/default.log"
+
+[database.test]
+path = "data/test.log"
+
+[database.tester]

--- a/config.default.toml
+++ b/config.default.toml
@@ -10,6 +10,5 @@ verbose = 2
 directory = "./data"
 
 [database.test]
-directory = "./data2"
 
 [database.tester]

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -81,6 +81,16 @@ ok  	github.com/dburkart/fossil/pkg/server	19.132s
 ```
 
 With the above results in mind we went with the MapBased mux for now in-order to allow for quick changes and low memory usage at the minor cost of some CPU performance.
+
+##### Server Structure
+Fossil server can be run with many logical databases being served from a single physical server instance. When connecting to the server you may include a database in the connection string selecting the logical database you wish to connect to for operations.
+
+##### Server Startup
+For each `database` config block, a logical database item is created and added to the map of databases available on the server. 
+
+#### Client Connections and Databases
+When a request hits the server the client sets the database it is working with as the initial request which is set on each subsequent message for processing in the handlers. The database defaults to `default` if there is no database negotiated.
+
 ## Data Types (WIP)
 
 By default, data sent to fossil is stored as an opaque blob of bytes in the database. This unstructured data can not 

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -9,12 +9,13 @@ package database
 import (
 	"bytes"
 	"encoding/gob"
-	"io/ioutil"
-	"log"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/rs/zerolog"
 )
 
 type Database struct {
@@ -29,11 +30,12 @@ type Database struct {
 	// Private fields
 	writeLock   sync.Mutex
 	appendCount int
+	log         zerolog.Logger
 }
 
 func (d *Database) appendInternal(data Datum) {
 	if success, _ := d.Segments[d.Current].Append(data); !success {
-		log.Fatal("We should never not have enough segments, since our write-ahead log creates them")
+		d.log.Fatal().Msg("We should never not have enough segments, since our write-ahead log creates them")
 	}
 	d.appendCount += 1
 }
@@ -73,13 +75,13 @@ func (d *Database) splatToDisk() {
 	enc := gob.NewEncoder(&encoded)
 	err := enc.Encode(d)
 	if err != nil {
-		log.Fatal("encode:", err)
+		d.log.Fatal().Err(err).Msg("error gob encoding database")
 	}
 
 	backupDBPath := filepath.Join(d.Path, "database.bak")
 	file, err := os.OpenFile(backupDBPath, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
-		log.Fatal(err)
+		d.log.Fatal().Err(err).Msg("unable to openfile")
 	}
 	defer file.Close()
 
@@ -92,12 +94,12 @@ func (d *Database) splatToDisk() {
 	// First, overwrite the database
 	err = os.Rename(backupDBPath, filepath.Join(d.Path, "database"))
 	if err != nil {
-		log.Fatal(err)
+		d.log.Fatal().Err(err).Msg("error renaming database file")
 	}
 	// Next, zero out the WriteAheadLog
 	err = os.Remove(filepath.Join(d.Path, "wal.log"))
 	if err != nil {
-		log.Fatal(err)
+		d.log.Fatal().Err(err).Msg("error removing wal.log")
 	}
 	d.appendCount = 0
 }
@@ -248,34 +250,40 @@ func (d *Database) Retrieve(q Query) []Entry {
 	return results
 }
 
-func NewDatabase(location string) *Database {
+// NewDatabase creates a new database object in memory and creates the
+// directory and files on disk for storing the data
+// location is the base directory for creating the database
+func NewDatabase(log zerolog.Logger, name string, location string) (*Database, error) {
 	var db Database
+
+	directory := filepath.Join(location, name)
+
 	// If the path does not exist, create a new directory
-	fileinfo, err := os.Stat(location)
+	fileinfo, err := os.Stat(directory)
 	if os.IsNotExist(err) {
-		err := os.Mkdir(location, 0700)
+		err := os.Mkdir(directory, 0700)
 		if err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
 	} else if !fileinfo.IsDir() {
-		log.Fatal("Supplied path is not a directory")
+		return nil, fmt.Errorf("supplied path is not a directory")
 	}
 
-	if _, err := os.Stat(filepath.Join(location, "database")); err == nil {
-		contents, err := ioutil.ReadFile(filepath.Join(location, "database"))
+	if _, err := os.Stat(filepath.Join(directory, "database")); err == nil {
+		contents, err := os.ReadFile(filepath.Join(directory, "database"))
 		if err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
 
 		dec := gob.NewDecoder(bytes.NewBuffer(contents))
 		err = dec.Decode(&db)
 		if err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
-	} else if _, err := os.Stat(filepath.Join(location, "wal.log")); err == nil {
+	} else if _, err := os.Stat(filepath.Join(directory, "wal.log")); err == nil {
 		db = Database{
 			Version:    1,
-			Path:       location,
+			Path:       directory,
 			Segments:   []Segment{},
 			Current:    0,
 			Topics:     make(map[string]int),
@@ -286,7 +294,7 @@ func NewDatabase(location string) *Database {
 	} else {
 		db = Database{
 			Version:    1,
-			Path:       location,
+			Path:       directory,
 			Segments:   []Segment{},
 			Current:    0,
 			Topics:     make(map[string]int),
@@ -297,5 +305,5 @@ func NewDatabase(location string) *Database {
 	if db.appendCount > SegmentSize {
 		db.splatToDisk()
 	}
-	return &db
+	return &db, nil
 }

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -33,7 +33,7 @@ type Database struct {
 	log         zerolog.Logger
 }
 
-func (d *Database) appendInternal(data Datum) {
+func (d *Database) appendInternal(data *Datum) {
 	if success, _ := d.Segments[d.Current].Append(data); !success {
 		d.log.Fatal().Msg("We should never not have enough segments, since our write-ahead log creates them")
 	}
@@ -131,6 +131,11 @@ func (d *Database) Append(data []byte, topic string) {
 
 	topicID := d.AddTopic(topic)
 
+	// Explicitly copy the data before taking the lock to minimize resource
+	// contention
+	e := Datum{Data: make([]byte, len(data)), TopicID: topicID}
+	copy(e.Data, data)
+
 	if d.appendCount > SegmentSize {
 		d.splatToDisk()
 	}
@@ -139,24 +144,23 @@ func (d *Database) Append(data []byte, topic string) {
 	defer d.writeLock.Unlock()
 
 	wal := WriteAheadLog{filepath.Join(d.Path, "wal.log")}
-	// Add a new segment to the log if needed
-	if len(d.Segments) == 0 || d.Segments[d.Current].Size >= SegmentSize {
-		wal.AddSegment(appendTime)
-	}
-	if len(d.Segments) == 0 {
-		d.Segments = append(d.Segments, Segment{HeadTime: appendTime})
-	}
-	// Calculate the delta
-	delta := appendTime.Sub(d.Segments[d.Current].HeadTime)
-	e := Datum{Data: data, TopicID: topicID, Delta: delta}
-	wal.AddEvent(&e)
 
-	// Create a new segment if needed
+	// Add a new segment to the log if needed
 	if d.Segments[d.Current].Size >= SegmentSize {
+		wal.AddSegment(appendTime)
 		d.Segments = append(d.Segments, Segment{HeadTime: appendTime})
 		d.Current += 1
 	}
-	d.appendInternal(e)
+	if len(d.Segments) == 0 {
+		wal.AddSegment(appendTime)
+		d.Segments = append(d.Segments, Segment{HeadTime: appendTime})
+	}
+
+	// Calculate the delta
+	delta := appendTime.Sub(d.Segments[d.Current].HeadTime)
+	e.Delta = delta
+	wal.AddEvent(&e)
+	d.appendInternal(&e)
 }
 
 func (d *Database) entriesFromData(s *Segment, data []Datum) []Entry {

--- a/pkg/database/log.go
+++ b/pkg/database/log.go
@@ -56,7 +56,7 @@ func (w *WriteAheadLog) ApplyToDB(d *Database) {
 			if err != nil {
 				log.Fatal(err)
 			}
-			d.appendInternal(datum)
+			d.appendInternal(&datum)
 		case actionAddSegment:
 			var segment Segment
 			err := dec.Decode(&segment.HeadTime)

--- a/pkg/database/segment.go
+++ b/pkg/database/segment.go
@@ -27,7 +27,7 @@ type Segment struct {
 	Size     int
 }
 
-func (s *Segment) Append(d Datum) (bool, error) {
+func (s *Segment) Append(d *Datum) (bool, error) {
 	if s.Size >= SegmentSize {
 		return false, errors.New("cannot add additional elements, segment at maximum size")
 	}
@@ -36,7 +36,7 @@ func (s *Segment) Append(d Datum) (bool, error) {
 		d.Delta = time.Now().Sub(s.HeadTime)
 	}
 
-	s.Series[s.Size] = d
+	s.Series[s.Size] = *d
 	s.Size += 1
 
 	return true, nil

--- a/pkg/database/segment_test.go
+++ b/pkg/database/segment_test.go
@@ -25,7 +25,7 @@ func createFullSegment() Segment {
 	}
 
 	for i := 0; i < SegmentSize; i++ {
-		segment.Append(event)
+		segment.Append(&event)
 		event.Delta += 60000000000
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,7 +48,12 @@ func New(log zerolog.Logger, dbConfigs map[string]DatabaseConfig, port, metricsP
 	dbMap := make(map[string]*database.Database)
 	for k, v := range dbConfigs {
 		log.Info().Str("name", v.Name).Str("directory", v.Directory).Msg("initializing database")
-		dbMap[k] = database.NewDatabase(v.Directory)
+		dbLogger := log.With().Str("db", v.Name).Logger()
+		db, err := database.NewDatabase(dbLogger, v.Name, v.Directory)
+		if err != nil {
+			dbLogger.Fatal().Err(err).Msg("error initializing database")
+		}
+		dbMap[k] = db
 	}
 
 	return Server{


### PR DESCRIPTION
#19 

This is a big one, and might need a few more changes. There is an output trace below of how the config is loaded, we will likely want to build an object to pass to database or have some other logic mapping databases to their files.

```shell
❯ go run main.go -vvv client -c ./config.default.toml
2022-11-30T23:32:06-05:00 TRC cmd/fossil/config.go:51 > database.default.path = data/default.log
2022-11-30T23:32:06-05:00 TRC cmd/fossil/config.go:47 > database.test.path = data/test.log
2022-11-30T23:32:06-05:00 TRC cmd/fossil/config.go:102 > database.names=[tester test default]
2022-11-30T23:32:06-05:00 TRC cmd/fossil/config.go:102 > fossil.prom-port=2112
2022-11-30T23:32:06-05:00 TRC cmd/fossil/config.go:102 > fossil.host=fossil://local/default
2022-11-30T23:32:06-05:00 TRC cmd/fossil/config.go:102 > database.test.path=data/test.log
2022-11-30T23:32:06-05:00 TRC cmd/fossil/config.go:102 > config=./config.default.toml
2022-11-30T23:32:06-05:00 TRC cmd/fossil/config.go:102 > fossil.port=8000
2022-11-30T23:32:06-05:00 TRC cmd/fossil/config.go:102 > database.path=data/default.log
2022-11-30T23:32:06-05:00 TRC cmd/fossil/config.go:102 > fossil.local=true
2022-11-30T23:32:06-05:00 TRC cmd/fossil/config.go:102 > fossil.verbose=3
```