### PR TITLE
Internals: Append needs to copy passed in `[]byte` data

### DIFF
--- a/pkg/database/log.go
+++ b/pkg/database/log.go
@@ -56,7 +56,7 @@ func (w *WriteAheadLog) ApplyToDB(d *Database) {
 			if err != nil {
 				log.Fatal(err)
 			}
-			d.appendInternal(datum)
+			d.appendInternal(&datum)
 		case actionAddSegment:
 			var segment Segment
 			err := dec.Decode(&segment.HeadTime)

--- a/pkg/database/segment.go
+++ b/pkg/database/segment.go
@@ -27,7 +27,7 @@ type Segment struct {
 	Size     int
 }
 
-func (s *Segment) Append(d Datum) (bool, error) {
+func (s *Segment) Append(d *Datum) (bool, error) {
 	if s.Size >= SegmentSize {
 		return false, errors.New("cannot add additional elements, segment at maximum size")
 	}
@@ -36,7 +36,7 @@ func (s *Segment) Append(d Datum) (bool, error) {
 		d.Delta = time.Now().Sub(s.HeadTime)
 	}
 
-	s.Series[s.Size] = d
+	s.Series[s.Size] = *d
 	s.Size += 1
 
 	return true, nil

--- a/pkg/database/segment_test.go
+++ b/pkg/database/segment_test.go
@@ -25,7 +25,7 @@ func createFullSegment() Segment {
 	}
 
 	for i := 0; i < SegmentSize; i++ {
-		segment.Append(event)
+		segment.Append(&event)
 		event.Delta += 60000000000
 	}
 


### PR DESCRIPTION
Since slices are passed by reference and not value, we need to explicitly `copy()` the slice before inserting it into our in-memory database. Since the write-ahead-log uses the gob serializer, that was already copying the slice for us, meaning that the log was never corrupted.

Aside: the github-generated name for this branch is ridiculous