### PR TITLE
Implement time-predicate support

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -20,7 +20,7 @@ time-predicate  = ( "since" time-expression ) / ( "before" time-expression ) /
 time-expression = ( time-whence ( "-" / "+" ) time-quantity ) / time-whence
 time-whence     = "~now" / "~(" RFC3339 ")"
 time-quantity   = time-term *( ( "-" / "+" ) time-term )
-time-term       = time-atom *( ( "/" / "*" ) time-atom )
+time-term       = time-atom *( "*" time-atom )
 time-atom       = number / timespan
 timespan        = "@second" / "@minute" / "@hour" / "@day" / "@week" / "@month" / "@year"
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -5,7 +5,7 @@ query           = quantifier [ identifier ] [ topic-selector ] [ time-predicate 
 
 ; Quantifier
 quantifier      = "all" / sample
-sample          = "sample(" timespan ")"
+sample          = "sample(" time-quantity ")"
 
 ; Identifier
 identifier      = 1*(ALPHA / DIGIT)

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -15,7 +15,7 @@ topic-selector  = "in" topic
 topic           = "/" 1*(ALPHA / DIGIT / "/")
 
 ; Time
-time-predicate  = ( "since" time-expression ) / ( "until" time-expression ) / 
+time-predicate  = ( "since" time-expression ) / ( "before" time-expression ) / 
                   ( "between" time-expression "," time-expression )
 time-expression = ( time-whence ( "-" / "+" ) time-quantity ) / time-whence
 time-whence     = "~now" / "~" RFC3339

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -16,11 +16,13 @@ topic           = "/" 1*(ALPHA / DIGIT / "/")
 
 ; Time
 time-predicate  = ( "since" time-expression ) / ( "until" time-expression ) / 
-                  ( "between" time-expression ".." time-expression )
-time-whence     = "~now" / "~begin" / "~yesterday"/ "~" iso8601
-time-quantity   = timespan / time-quantity ( "*" / "+" / "-" ) number
+                  ( "between" time-expression "," time-expression )
+time-expression = ( time-whence ( "-" / "+" ) time-quantity ) / time-whence
+time-whence     = "~now" / "~" RFC3339
+time-quantity   = time-term *( ( "-" / "+" ) time-term )
+time-term       = time-atom *( ( "/" / "*" ) time-atom )
+time-atom       = number / timespan
 timespan        = "@second" / "@minute" / "@hour" / "@day" / "@week" / "@month" / "@year"
-time-expression = ( time-whence ( "-" / "+" ) time-quantity ) / time-quantity
 
 ; Data
 data-predicate  = "->" data-expression

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -18,7 +18,7 @@ topic           = "/" 1*(ALPHA / DIGIT / "/")
 time-predicate  = ( "since" time-expression ) / ( "before" time-expression ) / 
                   ( "between" time-expression "," time-expression )
 time-expression = ( time-whence ( "-" / "+" ) time-quantity ) / time-whence
-time-whence     = "~now" / "~" RFC3339
+time-whence     = "~now" / "~(" RFC3339 ")"
 time-quantity   = time-term *( ( "-" / "+" ) time-term )
 time-term       = time-atom *( ( "/" / "*" ) time-atom )
 time-atom       = number / timespan

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -227,6 +227,26 @@ func (d *Database) Retrieve(q Query) []Entry {
 		endSubIndex, _ = d.Segments[endIndex].FindApproximateDatum(q.Range.End)
 		// End of the range should be inclusive
 		endSubIndex += 1
+
+		// Our binary search is kind of crude, in that it "fuzzy" matches the start
+		// and end of our range. So we have to do a quick bounds check on both sides
+		// to make sure that q.Range.Start <= startSubIndex <= q.Range.End
+		switch q.RangeSemantics {
+		case "since":
+			// Ensure start is correct
+			startDatum := d.Segments[startIndex].Series[startSubIndex]
+			startTime := d.Segments[startIndex].HeadTime.Add(startDatum.Delta)
+			if startTime.Before(q.Range.Start) {
+				startSubIndex += 1
+			}
+		case "before":
+			// Ensure end is correct
+			endDatum := d.Segments[endIndex].Series[endSubIndex]
+			endTime := d.Segments[startIndex].HeadTime.Add(endDatum.Delta)
+			if endTime.After(q.Range.End) {
+				endSubIndex -= 1
+			}
+		}
 	}
 
 	// Handle the case where all of our datum is in a single segment

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -206,10 +206,10 @@ func (d *Database) Retrieve(q Query) []Entry {
 			}
 		}
 
-		// If we haven't found a start to our range, then it's outside the
-		// bounds of our database.
+		// If start has not been found, we still need to search the last segment
+		// of the database
 		if !startFound {
-			return results
+			startIndex = d.Current
 		}
 	}
 
@@ -225,6 +225,8 @@ func (d *Database) Retrieve(q Query) []Entry {
 	if q.Range != nil {
 		startSubIndex, _ = d.Segments[startIndex].FindApproximateDatum(q.Range.Start)
 		endSubIndex, _ = d.Segments[endIndex].FindApproximateDatum(q.Range.End)
+		// End of the range should be inclusive
+		endSubIndex += 1
 	}
 
 	// Handle the case where all of our datum is in a single segment
@@ -297,6 +299,11 @@ func NewDatabase(location string) *Database {
 			TopicCount: 0,
 		}
 		db.AddTopic("/")
+		// TODO: Generalize this
+		sTime := time.Now()
+		wal := WriteAheadLog{filepath.Join(db.Path, "wal.log")}
+		wal.AddSegment(sTime)
+		db.Segments = append(db.Segments, Segment{HeadTime: sTime})
 	}
 	if db.appendCount > SegmentSize {
 		db.splatToDisk()

--- a/pkg/database/query.go
+++ b/pkg/database/query.go
@@ -20,7 +20,8 @@ type TimeRange struct {
 //   - Time Range
 //   - Data Predicate (TODO!)
 type Query struct {
-	Quantifier string
-	Topics     []string
-	Range      *TimeRange // nil means entire history (no time range)
+	Quantifier     string
+	Topics         []string
+	Range          *TimeRange // nil means entire history (no time range)
+	RangeSemantics string     // none, before, since, between
 }

--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -7,7 +7,9 @@
 package query
 
 import (
+	"fmt"
 	"github.com/dburkart/fossil/pkg/database"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -57,6 +59,10 @@ type (
 	}
 
 	TimespanNode struct {
+		BaseNode
+	}
+
+	NumberNode struct {
 		BaseNode
 	}
 )
@@ -258,4 +264,14 @@ func (t TimespanNode) DerivedValue() int64 {
 		return int64(time.Second)
 	}
 	return 0
+}
+
+//-- NumberNode
+
+func (n NumberNode) DerivedValue() int64 {
+	i, err := strconv.ParseInt(n.Value, 10, 64)
+	if err != nil {
+		panic(fmt.Sprintf("NumberNode had unexpected non-numerical value: %s", n.Value))
+	}
+	return i
 }

--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -131,12 +131,12 @@ func (q QuantifierNode) GenerateFilter(db *database.Database) database.Filter {
 		case "all":
 			return data
 		case "sample":
-			timespan, ok := q.Children()[0].(*TimespanNode)
+			quantity, ok := q.Children()[0].(Numeric)
 			if !ok {
 				panic("Expected child to be of type *TimespanNode")
 			}
 
-			sampleDuration := timespan.DerivedValue()
+			sampleDuration := quantity.DerivedValue()
 			nextTime := data[0].Time
 			filtered := database.Entries{}
 

--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -246,7 +246,7 @@ func (t TimeWhenceNode) Time() (time.Time, error) {
 	case t.Value == "~now":
 		return time.Now(), nil
 	default:
-		return time.Parse(time.RFC3339, t.Value[1:])
+		return time.Parse(time.RFC3339, t.Value[2:len(t.Value)-1])
 	}
 }
 

--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -48,6 +48,10 @@ type (
 		BaseNode
 	}
 
+	TimeWhenceNode struct {
+		BaseNode
+	}
+
 	TimespanNode struct {
 		BaseNode
 	}
@@ -171,6 +175,20 @@ func (q TopicSelectorNode) GenerateFilter(db *database.Database) database.Filter
 
 		return filtered
 	}
+}
+
+//-- TimeExpression
+
+func (t TimeExpressionNode) Time() (time.Time, error) {
+	// TODO: Support full time-expression syntax here
+	child := t.Children()[0].(*TimeWhenceNode)
+	return child.Time()
+}
+
+//-- TimeWhence
+
+func (t TimeWhenceNode) Time() (time.Time, error) {
+	return time.Parse(time.RFC3339, t.Value[1:])
 }
 
 //-- TimespanNode

--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -58,6 +58,10 @@ type (
 		BaseNode
 	}
 
+	BinaryOpNode struct {
+		BaseNode
+	}
+
 	TimespanNode struct {
 		BaseNode
 	}
@@ -244,6 +248,23 @@ func (t TimeWhenceNode) Time() (time.Time, error) {
 	default:
 		return time.Parse(time.RFC3339, t.Value[1:])
 	}
+}
+
+//-- BinaryOpNode
+
+func (b BinaryOpNode) DerivedValue() int64 {
+	lh, rh := b.Children()[0].(Numeric), b.Children()[1].(Numeric)
+
+	switch b.Value {
+	case "*":
+		return lh.DerivedValue() * rh.DerivedValue()
+	case "-":
+		return lh.DerivedValue() - rh.DerivedValue()
+	case "+":
+		return lh.DerivedValue() + rh.DerivedValue()
+	}
+
+	panic(fmt.Sprintf("Unknown operator '%s'", b.Value))
 }
 
 //-- TimespanNode

--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -199,7 +199,7 @@ func (t TimePredicateNode) GenerateFilter(db *database.Database) database.Filter
 
 	return func(data database.Entries) database.Entries {
 		if data == nil {
-			return db.Retrieve(database.Query{Range: &timeRange})
+			return db.Retrieve(database.Query{Range: &timeRange, RangeSemantics: t.Value})
 		}
 
 		// TODO: Handle non-nil case! Let's factor out some of the Retrieve functionality for

--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -18,10 +18,42 @@ type ASTNode interface {
 	Walk(*database.Database) []database.Filter
 }
 
-type BaseNode struct {
-	Value    string
-	children []ASTNode
-}
+type (
+	BaseNode struct {
+		Value    string
+		children []ASTNode
+	}
+
+	QueryNode struct {
+		BaseNode
+	}
+
+	QuantifierNode struct {
+		BaseNode
+	}
+
+	TopicSelectorNode struct {
+		BaseNode
+	}
+
+	TopicNode struct {
+		BaseNode
+	}
+
+	TimePredicateNode struct {
+		BaseNode
+	}
+
+	TimeExpressionNode struct {
+		BaseNode
+	}
+
+	TimespanNode struct {
+		BaseNode
+	}
+)
+
+//-- BaseNode
 
 func (b *BaseNode) Children() []ASTNode {
 	return b.children
@@ -63,17 +95,13 @@ func (b *BaseNode) Walk(d *database.Database) []database.Filter {
 	return b.descend(d, b)
 }
 
-type QueryNode struct {
-	BaseNode
-}
+//-- QueryNode
 
 func (q QueryNode) GenerateFilter(_ *database.Database) database.Filter {
 	return nil
 }
 
-type QuantifierNode struct {
-	BaseNode
-}
+//-- QuantifierNode
 
 func (q QuantifierNode) GenerateFilter(db *database.Database) database.Filter {
 	return func(data database.Entries) database.Entries {
@@ -109,9 +137,7 @@ func (q QuantifierNode) GenerateFilter(db *database.Database) database.Filter {
 	}
 }
 
-type TopicSelectorNode struct {
-	BaseNode
-}
+//-- TopicSelectorNode
 
 func (q TopicSelectorNode) GenerateFilter(db *database.Database) database.Filter {
 	topic, ok := q.Children()[0].(*TopicNode)
@@ -147,13 +173,7 @@ func (q TopicSelectorNode) GenerateFilter(db *database.Database) database.Filter
 	}
 }
 
-type TopicNode struct {
-	BaseNode
-}
-
-type TimespanNode struct {
-	BaseNode
-}
+//-- TimespanNode
 
 func (t TimespanNode) Duration() time.Duration {
 	switch t.Value {

--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -234,9 +234,22 @@ func (t TimePredicateNode) GenerateFilter(db *database.Database) database.Filter
 //-- TimeExpressionNode
 
 func (t TimeExpressionNode) Time() (time.Time, error) {
-	// TODO: Support full time-expression syntax here
-	child := t.Children()[0].(*TimeWhenceNode)
-	return child.Time()
+	lh := t.Children()[0].(*TimeWhenceNode)
+	tm, err := lh.Time()
+	if err != nil {
+		return tm, err
+	}
+
+	switch t.Value {
+	case "-":
+		rh := t.Children()[1].(Numeric)
+		return tm.Add(time.Duration(rh.DerivedValue() * -1)), err
+	case "+":
+		rh := t.Children()[1].(Numeric)
+		return tm.Add(time.Duration(rh.DerivedValue())), err
+	}
+
+	return tm, err
 }
 
 //-- TimeWhenceNode

--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -184,6 +184,15 @@ func (t TimePredicateNode) GenerateFilter(db *database.Database) database.Filter
 	var err error
 
 	switch t.Value {
+	case "before":
+		endTime, err = t.Children()[0].(*TimeExpressionNode).Time()
+		// It shouldn't be possible there to be an error here (we should catch
+		// it earlier when parsing, so panic
+		if err != nil {
+			panic(err)
+		}
+
+		startTime = db.Segments[0].HeadTime
 	case "since":
 		startTime, err = t.Children()[0].(*TimeExpressionNode).Time()
 		// It shouldn't be possible there to be an error here (we should catch

--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -18,6 +18,10 @@ type ASTNode interface {
 	Walk(*database.Database) []database.Filter
 }
 
+type Numeric interface {
+	DerivedValue() int64
+}
+
 type (
 	BaseNode struct {
 		Value    string
@@ -122,14 +126,14 @@ func (q QuantifierNode) GenerateFilter(db *database.Database) database.Filter {
 				panic("Expected child to be of type *TimespanNode")
 			}
 
-			sampleDuration := timespan.Duration()
+			sampleDuration := timespan.DerivedValue()
 			nextTime := data[0].Time
 			filtered := database.Entries{}
 
 			for _, val := range data {
 				if val.Time.After(nextTime) || val.Time.Equal(nextTime) {
 					filtered = append(filtered, val)
-					nextTime = val.Time.Add(sampleDuration)
+					nextTime = val.Time.Add(time.Duration(sampleDuration))
 				}
 			}
 
@@ -238,20 +242,20 @@ func (t TimeWhenceNode) Time() (time.Time, error) {
 
 //-- TimespanNode
 
-func (t TimespanNode) Duration() time.Duration {
+func (t TimespanNode) DerivedValue() int64 {
 	switch t.Value {
 	case "@year":
-		return time.Hour * 24 * 365
+		return int64(time.Hour * 24 * 365)
 	case "@month":
-		return time.Hour * 24 * 30
+		return int64(time.Hour * 24 * 30)
 	case "@day":
-		return time.Hour * 24
+		return int64(time.Hour * 24)
 	case "@hour":
-		return time.Hour
+		return int64(time.Hour)
 	case "@minute":
-		return time.Minute
+		return int64(time.Minute)
 	case "@second":
-		return time.Second
+		return int64(time.Second)
 	}
 	return 0
 }

--- a/pkg/query/parser.go
+++ b/pkg/query/parser.go
@@ -143,12 +143,12 @@ func (p *Parser) topic() ASTNode {
 //
 // Grammar:
 //
-//	time-predicate  = ( "since" time-expression ) / ( "until" time-expression ) /
+//	time-predicate  = ( "since" time-expression ) / ( "before" time-expression ) /
 //	                ( "between" time-expression ".." time-expression )
 func (p *Parser) timePredicate() ASTNode {
 	tok := p.Scanner.Emit()
 
-	if tok.Type != TOK_KEYWORD || (tok.Lexeme != "since" && tok.Lexeme != "until" &&
+	if tok.Type != TOK_KEYWORD || (tok.Lexeme != "since" && tok.Lexeme != "before" &&
 		tok.Lexeme != "between") {
 		// time-predicates are optional, so don't error out
 		p.Scanner.Rewind()

--- a/pkg/query/parser.go
+++ b/pkg/query/parser.go
@@ -76,22 +76,13 @@ func (p *Parser) quantifier() ASTNode {
 
 	if tok.Lexeme == "sample" {
 		tok = p.Scanner.Emit()
-
 		if tok.Type != TOK_PAREN_L {
 			panic(fmt.Sprintf("Error: unexpected token '%s', expected '('", tok.Lexeme))
 		}
 
-		tok = p.Scanner.Emit()
-
-		if tok.Type != TOK_TIMESPAN {
-			panic(fmt.Sprintf("Error: unexpected token '%s', expected valid timespan (@hour, @minute, @second, etc.)", tok.Lexeme))
-		}
-		q.AddChild(&TimespanNode{BaseNode{
-			Value: tok.Lexeme,
-		}})
+		q.AddChild(p.timeQuantity())
 
 		tok = p.Scanner.Emit()
-
 		if tok.Type != TOK_PAREN_R {
 			panic(fmt.Sprintf("Error: unexpected token '%s', expected ')'", tok.Lexeme))
 		}

--- a/pkg/query/parser.go
+++ b/pkg/query/parser.go
@@ -45,8 +45,14 @@ func (p *Parser) query() ASTNode {
 		q.AddChild(topicSelector)
 	}
 
-	// TODO: Check for time-predicate
-	// TODO: Check for data-predicate
+	timePredicate := p.timePredicate()
+	if timePredicate != nil {
+		q.AddChild(timePredicate)
+	}
+
+	// TODO: Check for data-predicate.
+	// 		 Note: this will have to be at the beginning of our filters, based
+	//	     on the current design
 
 	return &q
 }

--- a/pkg/query/parser_test.go
+++ b/pkg/query/parser_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestParseAllQuantifier(t *testing.T) {
@@ -52,5 +53,52 @@ func TestParseTopicSelector(t *testing.T) {
 	child := ast.Children()[0]
 	if fmt.Sprint(reflect.TypeOf(child)) != "*query.TopicNode" {
 		t.Errorf("wanted first child to be *query.TopicNode, found %s", reflect.TypeOf(child))
+	}
+}
+
+func TestParseTimePredicate(t *testing.T) {
+	p := Parser{
+		Scanner: Scanner{
+			Input: "since ~now",
+		},
+	}
+
+	ast := p.timePredicate()
+	if fmt.Sprint(reflect.TypeOf(ast)) != "*query.TimePredicateNode" {
+		t.Errorf("wanted root node to be *query.TimePredicateNode, found %s", reflect.TypeOf(ast))
+	}
+
+	child := ast.Children()[0]
+	if fmt.Sprint(reflect.TypeOf(child)) != "*query.TimeExpressionNode" {
+		t.Errorf("wanted first child to be *query.TimeExpressionNode, found %s", reflect.TypeOf(child))
+	}
+
+	child = child.Children()[0]
+	if fmt.Sprint(reflect.TypeOf(child)) != "*query.TimeWhenceNode" {
+		t.Errorf("wanted first child to be *query.TimeWhenceNode, found %s", reflect.TypeOf(child))
+	}
+}
+
+func TestTimeWhence(t *testing.T) {
+	p := Parser{
+		Scanner: Scanner{
+			Input: "~1996-12-19T16:39:57-08:00",
+		},
+	}
+
+	ast := p.timeWhence()
+	if fmt.Sprint(reflect.TypeOf(ast)) != "*query.TimeWhenceNode" {
+		t.Errorf("wanted first child to be *query.TimeWhenceNode, found %s", reflect.TypeOf(ast))
+	}
+
+	want, _ := time.Parse(time.RFC3339, "1996-12-19T16:39:57-08:00")
+
+	tm, err := ast.(*TimeWhenceNode).Time()
+	if err != nil {
+		t.Errorf("Got an error parsing time: %s", err)
+	}
+
+	if tm != want {
+		t.Errorf("wanted time-whence to parse to %s, got %s", want, tm)
 	}
 }

--- a/pkg/query/parser_test.go
+++ b/pkg/query/parser_test.go
@@ -98,7 +98,7 @@ func TestTimeWhence(t *testing.T) {
 		t.Errorf("Got an error parsing time: %s", err)
 	}
 
-	if tm != want {
+	if !tm.Equal(want) {
 		t.Errorf("wanted time-whence to parse to %s, got %s", want, tm)
 	}
 }

--- a/pkg/query/parser_test.go
+++ b/pkg/query/parser_test.go
@@ -82,7 +82,7 @@ func TestParseTimePredicate(t *testing.T) {
 func TestTimeWhence(t *testing.T) {
 	p := Parser{
 		Scanner: Scanner{
-			Input: "~1996-12-19T16:39:57-08:00",
+			Input: "~(1996-12-19T16:39:57-08:00)",
 		},
 	}
 

--- a/pkg/query/scanner.go
+++ b/pkg/query/scanner.go
@@ -241,6 +241,13 @@ func (s *Scanner) Emit() Token {
 				break
 			}
 			identifierFallthrough()
+		case r == 'b':
+			if strings.HasPrefix(s.Input[s.Pos:], "before") {
+				t.Type = TOK_KEYWORD
+				skip = len("before")
+				break
+			}
+			identifierFallthrough()
 		case r == 'i':
 			if strings.HasPrefix(s.Input[s.Pos:], "in") {
 				t.Type = TOK_KEYWORD

--- a/pkg/query/scanner.go
+++ b/pkg/query/scanner.go
@@ -96,24 +96,27 @@ func (s *Scanner) MatchTimeWhence() int {
 	pos := s.Pos + 1
 	r, _ = utf8.DecodeRuneInString(s.Input[pos:])
 
-	// If the next rune is a digit, we will assume that we need to match
+	// If the next rune is an open parenthesis, we will assume that we need to match
 	// an RFC3339 timestamp
-	if unicode.IsDigit(r) {
+	if r == '(' {
+		pos = pos + 1
+		r, _ = utf8.DecodeRuneInString(s.Input[pos:])
+
 		// Find the next boundary
 		var end int
-		for end = pos; !isNonTimeDelimiter(rune(s.Input[end])); end++ {
+		for end = pos; rune(s.Input[end]) != ')'; end++ {
 			if end == len(s.Input)-1 {
 				break
 			}
 		}
 
-		_, err := time.Parse(time.RFC3339, s.Input[pos:end+1])
+		_, err := time.Parse(time.RFC3339, s.Input[pos:end])
 		if err != nil {
 			return 0
 		}
 
 		// Add back one for '~', and another to include "end"
-		return end - pos + 2
+		return end - pos + 3
 	}
 
 	if strings.HasPrefix(s.Input[pos:], "now") {

--- a/pkg/query/scanner.go
+++ b/pkg/query/scanner.go
@@ -159,6 +159,15 @@ func (s *Scanner) Emit() Token {
 		case r == ')':
 			t.Type = TOK_PAREN_R
 			skip = width
+		case r == '*':
+			t.Type = TOK_STAR
+			skip = width
+		case r == '+':
+			t.Type = TOK_PLUS
+			skip = width
+		case r == '-':
+			t.Type = TOK_MINUS
+			skip = width
 		case r == '/':
 			t.Type = TOK_TOPIC
 			skip = s.MatchTopic()

--- a/pkg/query/scanner_test.go
+++ b/pkg/query/scanner_test.go
@@ -34,10 +34,10 @@ func TestMatchTimeWhence(t *testing.T) {
 		t.Errorf("~now should have width %d, not %d", len("~now"), width)
 	}
 
-	s.Input = "~2006-01-02T15:04:05-07:00"
+	s.Input = "~(2006-01-02T15:04:05-07:00)"
 	width = s.MatchTimeWhence()
-	if width != len("~1996-12-19T16:39:57-08:00") {
-		t.Errorf("RFC3339 should have length %d, not %d", len("~2006-01-02T15:04:05-07:00"), width)
+	if width != len("~(2006-01-02T15:04:05-07:00)") {
+		t.Errorf("RFC3339 should have length %d, not %d", len("~(2006-01-02T15:04:05-07:00)"), width)
 	}
 }
 

--- a/pkg/query/scanner_test.go
+++ b/pkg/query/scanner_test.go
@@ -6,7 +6,9 @@
 
 package query
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestMatchTimespan(t *testing.T) {
 	s := Scanner{Input: "@hour"}
@@ -21,6 +23,21 @@ func TestMatchTimespan(t *testing.T) {
 
 	if width != 0 {
 		t.Error("@bogus should not have a width!")
+	}
+}
+
+func TestMatchTimeWhence(t *testing.T) {
+	s := Scanner{Input: "~now"}
+
+	width := s.MatchTimeWhence()
+	if width != len("~now") {
+		t.Errorf("~now should have width %d, not %d", len("~now"), width)
+	}
+
+	s.Input = "~2006-01-02T15:04:05-07:00"
+	width = s.MatchTimeWhence()
+	if width != len("~1996-12-19T16:39:57-08:00") {
+		t.Errorf("RFC3339 should have length %d, not %d", len("~2006-01-02T15:04:05-07:00"), width)
 	}
 }
 

--- a/pkg/query/token.go
+++ b/pkg/query/token.go
@@ -21,6 +21,11 @@ const (
 	TOK_TIMESPAN
 	TOK_COMMA
 
+	// Arithmetic
+	TOK_PLUS
+	TOK_MINUS
+	TOK_STAR
+
 	TOK_PAREN_L
 	TOK_PAREN_R
 
@@ -49,6 +54,12 @@ func (t TokenType) ToString() string {
 		return "TOK_TIMESPAN"
 	case TOK_COMMA:
 		return "TOK_COMMA"
+	case TOK_PLUS:
+		return "TOK_PLUS"
+	case TOK_MINUS:
+		return "TOK_MINUS"
+	case TOK_STAR:
+		return "TOK_STAR"
 	case TOK_PAREN_L:
 		return "TOK_PAREN_L"
 	case TOK_PAREN_R:

--- a/pkg/query/token.go
+++ b/pkg/query/token.go
@@ -18,13 +18,16 @@ const (
 	TOK_NUMBER
 	TOK_STRING
 	TOK_TOPIC
-	TOK_TIMESPAN
 	TOK_COMMA
 
 	// Arithmetic
 	TOK_PLUS
 	TOK_MINUS
 	TOK_STAR
+
+	// Time
+	TOK_WHENCE
+	TOK_TIMESPAN
 
 	TOK_PAREN_L
 	TOK_PAREN_R
@@ -50,6 +53,8 @@ func (t TokenType) ToString() string {
 		return "TOK_STRING"
 	case TOK_TOPIC:
 		return "TOK_TOPIC"
+	case TOK_WHENCE:
+		return "TOK_WHENCE"
 	case TOK_TIMESPAN:
 		return "TOK_TIMESPAN"
 	case TOK_COMMA:


### PR DESCRIPTION
This PR:

  * Implements time-predicates
  * Improves sample() to take a time-quantity (instead of just a timespan)
  * Fixes a few retrieval accuracy bugs, [see this commit](https://github.com/dburkart/fossil/pull/39/commits/03bcf74118d5f699a0ecdee5677108019697903f) for more context
  * Changes the grammar slightly for usability reasons