### PR TITLE
Bubble syntax errors up to clients

### DIFF
--- a/cmd/fossil/client/client.go
+++ b/cmd/fossil/client/client.go
@@ -142,6 +142,7 @@ func clientPrompt(c net.Conn) {
 			fmt.Printf("\n> ")
 		}
 		line, err := rdr.ReadBytes('\n')
+		line = line[:len(line)-1]
 		history = append(history, string(line))
 		if err != nil {
 			if piped {
@@ -159,7 +160,7 @@ func clientPrompt(c net.Conn) {
 		if err != nil {
 			fmt.Printf("Err: unable to send command\n\t'%s'\n", err)
 		}
-		
+
 		resp, err := proto.ReadBytes(c)
 		if err != nil {
 			log.Error().Err(err).Msg("could not read bytes")

--- a/cmd/fossil/client/client.go
+++ b/cmd/fossil/client/client.go
@@ -103,7 +103,12 @@ func localPrompt(db *database.Database) {
 			log.Fatal().Err(err)
 		}
 
-		stmt := query.Prepare(db, line)
+		stmt, err := query.Prepare(db, line)
+		if err != nil {
+			fmt.Println(err.Error())
+			continue
+		}
+
 		result := stmt.Execute()
 
 		for _, val := range result.Data {

--- a/pkg/proto/responseWriter.go
+++ b/pkg/proto/responseWriter.go
@@ -7,6 +7,7 @@
 package proto
 
 import (
+	"encoding/binary"
 	"io"
 )
 
@@ -33,5 +34,12 @@ func (rw ResponseWriter) WriteMessage(t Marshaler) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return rw.w.Write(b)
+	lengthPrefix := make([]byte, 4)
+	binary.LittleEndian.PutUint32(lengthPrefix, uint32(len(b)))
+	n, err := rw.w.Write(lengthPrefix)
+	if err != nil {
+		return n, err
+	}
+	m, err := rw.w.Write(b)
+	return m + n, err
 }

--- a/pkg/query/parser.go
+++ b/pkg/query/parser.go
@@ -24,7 +24,7 @@ func NewSyntaxError(t Token, m string) SyntaxError {
 func (s *SyntaxError) FormatError(input string) string {
 	errorString := "Syntax error found in query:\n"
 	errorString += input
-	errorString += fmt.Sprintf("\n%s^%s ", strings.Repeat(" ", s.Location[0]), strings.Repeat("~", s.Location[1]-s.Location[0]-1))
+	errorString += fmt.Sprintf("%s^%s ", strings.Repeat(" ", s.Location[0]), strings.Repeat("~", s.Location[1]-s.Location[0]-1))
 	errorString += fmt.Sprintf("%s\n", s.Message)
 	return errorString
 }

--- a/pkg/query/parser.go
+++ b/pkg/query/parser.go
@@ -24,7 +24,7 @@ func NewSyntaxError(t Token, m string) SyntaxError {
 func (s *SyntaxError) FormatError(input string) string {
 	errorString := "Syntax error found in query:\n"
 	errorString += input
-	errorString += fmt.Sprintf("%s^%s ", strings.Repeat(" ", s.Location[0]), strings.Repeat("~", s.Location[1]-s.Location[0]-1))
+	errorString += fmt.Sprintf("\n%s^%s ", strings.Repeat(" ", s.Location[0]), strings.Repeat("~", s.Location[1]-s.Location[0]-1))
 	errorString += fmt.Sprintf("%s\n", s.Message)
 	return errorString
 }

--- a/pkg/query/parser_test.go
+++ b/pkg/query/parser_test.go
@@ -20,7 +20,7 @@ func TestParseAllQuantifier(t *testing.T) {
 		},
 	}
 
-	ast := p.Parse()
+	ast, _ := p.Parse()
 
 	if fmt.Sprint(reflect.TypeOf(ast)) != "*query.QueryNode" {
 		t.Errorf("wanted root node to be *query.QueryNode, found %s", reflect.TypeOf(ast))

--- a/pkg/query/prepare.go
+++ b/pkg/query/prepare.go
@@ -16,8 +16,7 @@ func Prepare(d *database.Database, statement string) (database.Filters, error) {
 	}
 
 	ast, err := p.Parse()
-
-	if ast == nil {
+	if err != nil {
 		return []database.Filter{}, err
 	}
 

--- a/pkg/query/prepare.go
+++ b/pkg/query/prepare.go
@@ -8,21 +8,21 @@ package query
 
 import "github.com/dburkart/fossil/pkg/database"
 
-func Prepare(d *database.Database, statement string) database.Filters {
+func Prepare(d *database.Database, statement string) (database.Filters, error) {
 	p := Parser{
 		Scanner{
 			Input: statement,
 		},
 	}
 
-	ast := p.Parse()
+	ast, err := p.Parse()
 
 	if ast == nil {
-		return []database.Filter{}
+		return []database.Filter{}, err
 	}
 
 	// Walk the tree
 	filters := ast.Walk(d)
 
-	return filters
+	return filters, err
 }

--- a/pkg/query/scanner.go
+++ b/pkg/query/scanner.go
@@ -311,7 +311,7 @@ func (s *Scanner) SkipToBoundary(boundary boundaryFunc) int {
 	r, width := utf8.DecodeRuneInString(s.Input[s.Pos:])
 	size := 0
 
-	for !boundary(r) {
+	for !boundary(r) && s.Pos+size < len(s.Input) {
 		size += width
 		r, width = utf8.DecodeRuneInString(s.Input[s.Pos+size:])
 	}

--- a/pkg/query/scanner.go
+++ b/pkg/query/scanner.go
@@ -281,6 +281,7 @@ func (s *Scanner) Emit() Token {
 	}
 
 	t.Lexeme = s.Input[s.Start:s.Pos]
+	t.Location = [2]int{s.Start, s.Pos}
 	s.Start = s.Pos
 
 	s.LastWidth = s.Start - oldStart

--- a/pkg/query/token.go
+++ b/pkg/query/token.go
@@ -76,6 +76,7 @@ func (t TokenType) ToString() string {
 }
 
 type Token struct {
-	Type   TokenType
-	Lexeme string
+	Type     TokenType
+	Lexeme   string
+	Location [2]int
 }

--- a/pkg/server/mux.go
+++ b/pkg/server/mux.go
@@ -114,12 +114,15 @@ func (c *conn) SetDatabase(name string, db *database.Database) {
 
 func (c *conn) Handle(conn *net.TCPConn) {
 	c.c = conn
+	defer c.c.Close()
+
 	c.rw = proto.NewResponseWriter(c.c)
 
 	for {
 		message, err := proto.ReadBytes(c.c)
 		if err != nil {
 			c.log.Error().Err(err).Msg("error reading message")
+			return
 		}
 
 		c.log.Trace().Int("read", len(message)).Msg("read from conn")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -97,7 +97,11 @@ func (s *Server) ServeDatabase() {
 			return
 		}
 
-		stmt := query.Prepare(r.Database(), q.Query)
+		stmt, err := query.Prepare(r.Database(), q.Query)
+		if err != nil {
+			rw.WriteMessage(proto.NewMessageWithType(proto.CommandError, proto.ErrResponse{Code: 504, Err: err}))
+			return
+		}
 		result := stmt.Execute()
 
 		resp := proto.QueryResponse{}


### PR DESCRIPTION
Instead of panicking on a string, we panic using a new `SyntaxError` struct, which records the location and error message. Further, in the `Parse()` function, instead of simply printing out the error, we instead set the error being returned to a formatted error message which includes context.

This resolves issue #43 