### PR TITLE
Support flexible date / times in the whence construction

### DIFF
--- a/pkg/query/parser.go
+++ b/pkg/query/parser.go
@@ -234,9 +234,9 @@ func (p *Parser) timeWhence() ASTNode {
 		when = time.Now()
 	case strings.HasPrefix(tok.Lexeme, "~("):
 		value := tok.Lexeme[2 : len(tok.Lexeme)-1]
-		when, err = time.Parse(time.RFC3339, value)
+		when, err = ParseVagueDateTime(value)
 		if err != nil {
-			panic(NewSyntaxError(tok, fmt.Sprintf("Error: Invalid date-time '%s', expected a valid RFC3339 date", value)))
+			panic(NewSyntaxError(tok, fmt.Sprintf("Error: %s", err.Error())))
 		}
 	}
 

--- a/pkg/query/parser_test.go
+++ b/pkg/query/parser_test.go
@@ -93,11 +93,7 @@ func TestTimeWhence(t *testing.T) {
 
 	want, _ := time.Parse(time.RFC3339, "1996-12-19T16:39:57-08:00")
 
-	tm, err := ast.(*TimeWhenceNode).Time()
-	if err != nil {
-		t.Errorf("Got an error parsing time: %s", err)
-	}
-
+	tm := ast.(*TimeWhenceNode).Time()
 	if !tm.Equal(want) {
 		t.Errorf("wanted time-whence to parse to %s, got %s", want, tm)
 	}

--- a/pkg/query/scanner.go
+++ b/pkg/query/scanner.go
@@ -8,7 +8,6 @@ package query
 
 import (
 	"strings"
-	"time"
 	"unicode"
 	"unicode/utf8"
 )
@@ -108,11 +107,6 @@ func (s *Scanner) MatchTimeWhence() int {
 			if end == len(s.Input)-1 {
 				break
 			}
-		}
-
-		_, err := time.Parse(time.RFC3339, s.Input[pos:end])
-		if err != nil {
-			return 0
 		}
 
 		// Add back one for '~', and another to include "end"

--- a/pkg/query/times.go
+++ b/pkg/query/times.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, Dana Burkart <dana.burkart@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+package query
+
+import (
+	"errors"
+	"fmt"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+var numberFormats = [...]string{
+	time.RFC3339,
+	time.RFC3339Nano,
+	time.RFC822,
+	time.RFC822Z,
+	time.Layout,
+	"2006/01/02",
+	"02/01/2006",
+}
+
+var letterFormats = [...]string{
+	"Jan 02, 2006",
+	time.RFC850,
+	time.UnixDate,
+	time.RFC1123,
+	time.RFC1123Z,
+	time.Stamp,
+}
+
+func ParseVagueDateTime(some string) (time.Time, error) {
+	first, _ := utf8.DecodeRuneInString(some)
+	var theFmt string
+	var found time.Time
+
+	switch {
+	case unicode.IsDigit(first):
+		for _, theFmt = range numberFormats {
+			tm, err := time.Parse(theFmt, some)
+			if err == nil {
+				found = tm
+				break
+			}
+		}
+	default:
+		for _, theFmt := range letterFormats {
+			tm, err := time.Parse(theFmt, some)
+			if err == nil {
+				found = tm
+				break
+			}
+		}
+	}
+
+	if found.IsZero() {
+		return found, errors.New(fmt.Sprintf("Specified time '%s' did not match a known timestamp", some))
+	}
+
+	return found, nil
+}


### PR DESCRIPTION
This adds support for a variety of date / time layouts that are now usable in a custom whence (`~(...)`). For example, the following now works, among a host of other possible layouts:

```
> QUERY all since ~(2022/12/05)
2022-12-06T09:48:04-08:00 TRC cmd/fossil/client/client.go:99 > message sent bytes=33
+------------------------------------+-------+----------------------+
|                TIME                | TOPIC |         DATA         |
+------------------------------------+-------+----------------------+
| 2022-12-06T09:47:48.51024114-08:00 | /foo  | new day, new message |
+------------------------------------+-------+----------------------+

> QUERY all since ~(2022/12/04)
2022-12-06T09:48:14-08:00 TRC cmd/fossil/client/client.go:99 > message sent bytes=33
+-------------------------------------+--------------+----------------------+
|                TIME                 |    TOPIC     |         DATA         |
+-------------------------------------+--------------+----------------------+
| 2022-12-04T10:38:14.282027325-08:00 | /foo/bar/baz | blah                 |
| 2022-12-04T10:41:19.106400274-08:00 | /foo/bar     | baz                  |
| 2022-12-04T10:41:39.712533708-08:00 | /foo         | bar                  |
| 2022-12-06T09:47:48.51024114-08:00  | /foo         | new day, new message |
+-------------------------------------+--------------+----------------------+
```

closes issue #44 