### PR TITLE
The query parser should fail if the whole input was not consumed.

### DIFF
--- a/pkg/query/parser.go
+++ b/pkg/query/parser.go
@@ -45,8 +45,22 @@ func (p *Parser) Parse() (query ASTNode, err error) {
 		}
 	}()
 
+	// Now that we don't allow valid input after a valid query, make sure to
+	// trim queries of whitespace
+	p.Scanner.Input = strings.Trim(p.Scanner.Input, " \t\n")
+
 	err = nil
 	query = p.query()
+
+	// If we didn't parse all the input, return an error
+	if p.Scanner.Pos != len(p.Scanner.Input) {
+		syntaxError := NewSyntaxError(Token{
+			Type:     TOK_INVALID,
+			Location: [2]int{p.Scanner.Pos, len(p.Scanner.Input) - 1},
+		}, "Error: query is not valid, starting here")
+		err = errors.New(syntaxError.FormatError(p.Scanner.Input))
+	}
+
 	return
 }
 

--- a/pkg/query/parser_test.go
+++ b/pkg/query/parser_test.go
@@ -13,6 +13,19 @@ import (
 	"time"
 )
 
+func TestGarbageAfterQuery(t *testing.T) {
+	p := Parser{
+		Scanner: Scanner{
+			Input: "all and then some garbage",
+		},
+	}
+
+	_, err := p.Parse()
+	if err == nil {
+		t.Fail()
+	}
+}
+
 func TestParseAllQuantifier(t *testing.T) {
 	p := Parser{
 		Scanner: Scanner{

--- a/pkg/query/parser_test.go
+++ b/pkg/query/parser_test.go
@@ -24,6 +24,17 @@ func TestGarbageAfterQuery(t *testing.T) {
 	if err == nil {
 		t.Fail()
 	}
+
+	p = Parser{
+		Scanner: Scanner{
+			Input: "all  \t\n",
+		},
+	}
+
+	_, err = p.Parse()
+	if err != nil {
+		t.Fail()
+	}
 }
 
 func TestParseAllQuantifier(t *testing.T) {


### PR DESCRIPTION
Realistically, having "queries that begin with valid syntax" being accepted by the parser seems terrible.