### PR TITLE
Protocol version advertisement

### DIFF
--- a/cmd/fossil/client/client.go
+++ b/cmd/fossil/client/client.go
@@ -132,6 +132,14 @@ func clientPrompt(c fossil.Client) {
 		}
 
 		switch msg.Command {
+		case proto.CommandVersion:
+			v := proto.VersionResponse{}
+			err = v.Unmarshal(msg.Data)
+			if err != nil {
+				log.Error().Err(err).Send()
+				continue
+			}
+			fmt.Printf("%d %s\n", v.Code, v.Version)
 		case proto.CommandStats:
 			t := proto.StatsResponse{}
 			err = t.Unmarshal(msg.Data)

--- a/cmd/fossil/client/client.go
+++ b/cmd/fossil/client/client.go
@@ -50,6 +50,7 @@ var Command = &cobra.Command{
 			client, err := fossil.NewClient(host)
 			if err != nil {
 				log.Error().Err(err).Str("address", target.Address).Msg("unable to connect to server")
+				os.Exit(1)
 			}
 
 			// REPL

--- a/pkg/proto/command.go
+++ b/pkg/proto/command.go
@@ -7,6 +7,8 @@
 package proto
 
 var (
+	// CommandVersion sends the version of the fossil protocol supported to the server / client
+	CommandVersion = "VERSION"
 	// CommandUse sets the current database context
 	CommandUse = "USE"
 	// CommandError sends an error code and a message to the client

--- a/pkg/proto/message.go
+++ b/pkg/proto/message.go
@@ -172,8 +172,8 @@ func (v VersionRequest) Marshal() ([]byte, error) {
 	return []byte(Version), nil
 }
 
-// UnMarshal ...
-func (v VersionRequest) UnMarshal(b []byte) error {
+// Unmarshal ...
+func (v *VersionRequest) Unmarshal(b []byte) error {
 	v.Version = string(b)
 
 	return nil
@@ -194,8 +194,8 @@ func (v VersionResponse) Marshal() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// UnMarshal ...
-func (v *VersionResponse) UnMarshal(b []byte) error {
+// Unmarshal ...
+func (v *VersionResponse) Unmarshal(b []byte) error {
 	buf := bytes.NewBuffer(b)
 	err := binary.Read(buf, binary.LittleEndian, &v.Code)
 	if err != nil {

--- a/pkg/proto/message_test.go
+++ b/pkg/proto/message_test.go
@@ -53,6 +53,43 @@ func BenchmarkReadMessageFull(b *testing.B) {
 	}
 }
 
+func TestVersionRequest(t *testing.T) {
+	req := VersionRequest{}
+
+	b, _ := req.Marshal()
+	if !bytes.Equal(b, []byte(Version)) {
+		t.Fail()
+	}
+
+	req = VersionRequest{"v1.2.3"}
+	b, _ = req.Marshal()
+	if !bytes.Equal(b, []byte(Version)) {
+		t.Fail()
+	}
+
+	err := req.UnMarshal(b)
+	if err != nil {
+		t.Fail()
+	}
+}
+
+func TestVersionResponse(t *testing.T) {
+	resp := VersionResponse{Code: 200}
+
+	b, _ := resp.Marshal()
+	err := resp.UnMarshal(b)
+	if err != nil {
+		t.Fail()
+	}
+
+	if resp.Code != 200 {
+		t.Fail()
+	}
+	if resp.Version != Version {
+		t.Fail()
+	}
+}
+
 func TestUseRequest(t *testing.T) {
 	req := UseRequest{}
 

--- a/pkg/proto/message_test.go
+++ b/pkg/proto/message_test.go
@@ -67,7 +67,7 @@ func TestVersionRequest(t *testing.T) {
 		t.Fail()
 	}
 
-	err := req.UnMarshal(b)
+	err := req.Unmarshal(b)
 	if err != nil {
 		t.Fail()
 	}
@@ -77,7 +77,7 @@ func TestVersionResponse(t *testing.T) {
 	resp := VersionResponse{Code: 200}
 
 	b, _ := resp.Marshal()
-	err := resp.UnMarshal(b)
+	err := resp.Unmarshal(b)
 	if err != nil {
 		t.Fail()
 	}

--- a/pkg/repl/parser.go
+++ b/pkg/repl/parser.go
@@ -35,6 +35,8 @@ func ParseREPLCommand(b []byte) proto.Message {
 	// Marshal message based on the command
 	command := strings.ToUpper(string(cmd))
 	switch command {
+	case proto.CommandVersion:
+		msg = proto.NewMessageWithType(proto.CommandVersion, proto.VersionRequest{})
 	case proto.CommandAppend:
 		req := proto.AppendRequest{}
 


### PR DESCRIPTION
This closes #57.

In this PR, we add support for:

 * A "version" command
 * VersionRequest / VersionResponse messages

This does not add any logic around rejecting / accepting particular versions of the fossil protocol; all versions are accepted by both client and server.

However, by adding this functionality before our first version, we'll be able to easily discover the version of a client / server in the future.