### PR TITLE
Fix for a concurrency bug related to database topic lookup.

### DIFF
--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -346,8 +346,8 @@ func NewDatabase(log zerolog.Logger, name string, location string) (*Database, e
 		db.splatToDisk()
 	}
 	// Set up our convenience topic map
-	for k := range db.TopicLookup {
-		db.topics[db.TopicLookup[k]] = k
+	for k, v := range db.TopicLookup {
+		db.topics[v] = k
 	}
 	return &db, nil
 }

--- a/pkg/query/ast.go
+++ b/pkg/query/ast.go
@@ -169,9 +169,9 @@ func (q TopicSelectorNode) GenerateFilter(db *database.Database) database.Filter
 	var topicFilter = make(map[string]bool)
 
 	// Since topics are hierarchical, we want any topic which has the desired prefix
-	for key := range db.Topics {
-		if strings.HasPrefix(key, topicName) {
-			topicFilter[key] = true
+	for _, topic := range db.TopicLookup {
+		if strings.HasPrefix(topic, topicName) {
+			topicFilter[topic] = true
 		}
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -208,8 +208,8 @@ func (s *Server) HandleList(rw proto.ResponseWriter, r *proto.Request) {
 			resp.ObjectList = append(resp.ObjectList, k)
 		}
 	} else if l.Object == "topics" {
-		for k := range r.Database().Topics {
-			resp.ObjectList = append(resp.ObjectList, k)
+		for _, v := range r.Database().TopicLookup {
+			resp.ObjectList = append(resp.ObjectList, v)
 		}
 	}
 


### PR DESCRIPTION
Since we were using a map to do quick lookups of topic indices, we could get into a situation where the map would change out from under a reader, since maps are not thread safe.

This change moves Database.Topics to be a private map, Database.topics, and protects all private usage with a `sync.RWMutex`. All external usage of topics must make use of Database.TopicLookup, which is a slice (and thus safe in Go).

In the future we can consider implementing a public API on a Database object to allow for faster lookups that enforces using the RWLock.

closes #81 