### PR TITLE
Fix a crash when reading from a database which as spilled it's log.

### DIFF
--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -319,6 +319,7 @@ func NewDatabase(log zerolog.Logger, name string, location string) (*Database, e
 		if err != nil {
 			return nil, err
 		}
+		db.topics = make(map[string]int)
 	} else if _, err := os.Stat(filepath.Join(directory, "wal.log")); err == nil {
 		db = Database{
 			Version:    1,


### PR DESCRIPTION
Turns out we weren't initializing our private topic map in this case.

closes #87 