### PR TITLE
Always apply the write-ahead-log when creating a new db.

### DIFF
--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -316,6 +316,8 @@ func NewDatabase(log zerolog.Logger, name string, location string) (*Database, e
 			return nil, err
 		}
 		db.topics = make(map[string]int)
+		wal := WriteAheadLog{filepath.Join(db.Path, "wal.log")}
+		wal.ApplyToDB(&db)
 	} else if _, err := os.Stat(filepath.Join(directory, "wal.log")); err == nil {
 		db = Database{
 			Version:    1,


### PR DESCRIPTION
closes #93 