### PR TITLE
Implement exponential backoff to try reconnecting to a lost server.

### DIFF
--- a/cmd/fossil/client/client.go
+++ b/cmd/fossil/client/client.go
@@ -209,7 +209,7 @@ func readlinePrompt(c fossil.Client) {
 		}
 		msg, err := c.Send(replMsg)
 		if err != nil {
-			log.Error().Err(err).Msg("error sending message to server")
+			log.Fatal().Err(err).Msg("error sending message to server")
 		}
 
 		switch msg.Command {


### PR DESCRIPTION
We only try this in the following error scenarios:

  * We got an EOF when reading data
  * We got a connection reset error
  * We got a pipe closed error

In the above scenarios, we will now attempt to replace the bad net.Conn from our pool with a good one using a new reconnection method.

I'm not sure if the time makes sense-- the backoff will wait for 1 second, then 2 seconds, then 4, and then give up. I'm not sure if those units of time are ideal or not, so that's worth a discussion.

closes #79 