### PR TITLE
Implement non-gobbed database format

### DIFF
--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -51,8 +51,9 @@ type Database struct {
 
 func (db *Database) Stats() Stats {
 	return Stats{
-		Segments:   len(db.Segments),
-		TopicCount: db.TopicCount,
+		Segments:      len(db.Segments),
+		TopicCount:    db.TopicCount,
+		SerializeTime: db.STime,
 	}
 }
 

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -18,6 +18,10 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// FossilDBVersion is the version of the database as recorded on disk.
+// This is primarily used for migration.
+const FossilDBVersion = 1
+
 type Database struct {
 	Version  int
 	Name     string
@@ -320,7 +324,7 @@ func NewDatabase(log zerolog.Logger, name string, location string) (*Database, e
 		wal.ApplyToDB(&db)
 	} else if _, err := os.Stat(filepath.Join(directory, "wal.log")); err == nil {
 		db = Database{
-			Version:    1,
+			Version:    FossilDBVersion,
 			Path:       directory,
 			Segments:   []Segment{},
 			Current:    0,
@@ -331,7 +335,7 @@ func NewDatabase(log zerolog.Logger, name string, location string) (*Database, e
 		wal.ApplyToDB(&db)
 	} else {
 		db = Database{
-			Version:    1,
+			Version:    FossilDBVersion,
 			Path:       directory,
 			Segments:   []Segment{},
 			Current:    0,

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -500,10 +500,12 @@ func NewDatabase(log zerolog.Logger, name string, location string) (*Database, e
 		return nil, fmt.Errorf("supplied path is not a directory")
 	}
 
-	if _, err := os.Stat(filepath.Join(directory, "database")); err == nil {
-		// FIXME: Migrate the database
-		return nil, errors.New("database migration not supported yet.")
-	} else if _, err := os.Stat(filepath.Join(directory, "metadata")); err == nil {
+	if MigrationIsNeeded(directory) {
+		// FIXME: Implement migration logic
+		panic("We need to perform a migration!")
+	}
+
+	if _, err := os.Stat(filepath.Join(directory, "metadata")); err == nil {
 		db = Database{
 			Path: directory,
 		}

--- a/pkg/database/migration.go
+++ b/pkg/database/migration.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Dana Burkart <dana.burkart@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+package database
+
+import (
+	"encoding/binary"
+	"os"
+	"path"
+)
+
+func DetectVersion(p string) uint32 {
+	// Versions without a metadata file that have a database file are version 1
+	if _, err := os.Stat(path.Join(p, "metadata")); os.IsNotExist(err) {
+		if _, err := os.Stat(path.Join(p, "database")); !os.IsNotExist(err) {
+			return 1
+		}
+
+		// If metadata simply does not exist yet, we are "version-less", and
+		// data must only exist in our write-ahead-log
+		return 0
+	}
+
+	// If we have a database file, read in the version
+	file, err := os.Open(path.Join(p, "metadata"))
+	if err != nil {
+		return 0
+	}
+	defer file.Close()
+
+	var version uint32
+	err = binary.Read(file, binary.LittleEndian, &version)
+	if err != nil {
+		return 0
+	}
+
+	return version
+}
+
+func MigrationIsNeeded(p string) bool {
+	version := DetectVersion(p)
+
+	if version == 0 {
+		return false
+	}
+
+	if version < FossilDBVersion {
+		return true
+	}
+
+	return false
+}

--- a/pkg/database/migration.go
+++ b/pkg/database/migration.go
@@ -7,12 +7,110 @@
 package database
 
 import (
+	"bytes"
 	"encoding/binary"
+	"encoding/gob"
+	"errors"
 	"os"
 	"path"
+	"time"
 )
 
-func DetectVersion(p string) uint32 {
+// deserializeFunc reads in a database of a specific version, and returns a
+// versioned database object
+type deserializeFunc func(string) (any, error)
+
+// migrationFunc takes a database of a specific version, and returns one of
+// another version
+type migrationFunc func(any) (any, error)
+
+// cleanupFunc cleans up a database path for a specific version
+type cleanupFunc func(string) error
+
+var deserializationFunctions = []deserializeFunc{
+	nil,
+	deserializeV1,
+}
+
+var migrationFunctions = []migrationFunc{
+	nil,
+	migrateV1ToV2,
+}
+
+var cleanupFunctions = []cleanupFunc{
+	nil,
+	cleanupV1,
+}
+
+//--
+//-- Database Version 1 migration handlers
+//--
+
+type databaseV1 struct {
+	Version     int
+	Name        string
+	Path        string
+	Segments    []Segment
+	Current     int
+	TopicLookup []string
+	TopicCount  int
+}
+
+func deserializeV1(p string) (any, error) {
+	file, err := os.ReadFile(path.Join(p, "database"))
+	if err != nil {
+		return nil, err
+	}
+
+	var db databaseV1
+	dec := gob.NewDecoder(bytes.NewBuffer(file))
+	err = dec.Decode(&db)
+	if err != nil {
+		return nil, err
+	}
+
+	return &db, nil
+}
+
+func migrateV1ToV2(db any) (any, error) {
+	// Assert that from is a v1 database
+	from, ok := db.(*databaseV1)
+	if !ok {
+		return nil, errors.New("attempted migration from a non v1 database")
+	}
+
+	to := Database{
+		Version:     uint32(from.Version),
+		Segments:    from.Segments,
+		Current:     uint32(from.Current),
+		TopicLookup: from.TopicLookup,
+		TopicCount:  from.TopicCount,
+		STime:       time.Now(),
+		Path:        from.Path,
+		Name:        from.Name,
+	}
+
+	return &to, nil
+}
+
+func cleanupV1(p string) error {
+	// Remove any "database" file
+	err := os.Remove(path.Join(p, "database"))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// The detectVersion function is responsible for detecting the version for a given
+// on-disk database. Starting with version 2, the version will always be stored as
+// the first 4 bytes of the database's metadata file. We special case version 1
+// since the format is completely different there.
+//
+// If this function returns a version of "0", that indicates that we think this is
+// a "version-less" database; i.e. the database has never spilled to disk, and only
+// a write-ahead log exists.
+func detectVersion(p string) uint32 {
 	// Versions without a metadata file that have a database file are version 1
 	if _, err := os.Stat(path.Join(p, "metadata")); os.IsNotExist(err) {
 		if _, err := os.Stat(path.Join(p, "database")); !os.IsNotExist(err) {
@@ -40,8 +138,11 @@ func DetectVersion(p string) uint32 {
 	return version
 }
 
-func MigrationIsNeeded(p string) bool {
-	version := DetectVersion(p)
+// migrationIsNeeded returns whether we think a migration is necessary.
+// This function bases the decision on whether the detected version is less
+// than FossilDBVersion (excluding 0, which indicates we are version-less).
+func migrationIsNeeded(p string) bool {
+	version := detectVersion(p)
 
 	if version == 0 {
 		return false
@@ -52,4 +153,67 @@ func MigrationIsNeeded(p string) bool {
 	}
 
 	return false
+}
+
+// MigrateDatabaseIfNeeded has all the logic necessary to migrate from
+// an old database through an arbitrary number of versions to the current
+// database version. It does this through use of 3 types of handler functions:
+//
+//   - A deserialization function, specific to a source DB version.
+//     This function is responsible for reading the on-disk structure of
+//     a specific database format.
+//
+//   - Some number of migration functions. Migration functions map from
+//     version n - 1 -> n, so each function will be called in succession,
+//     passing the results of the previous migration.
+//
+//   - A cleanup function, specific to a source DB version. This function
+//     is responsible for cleaning up any un-needed files after migration.
+func MigrateDatabaseIfNeeded(p string) error {
+	if !migrationIsNeeded(p) {
+		return nil
+	}
+
+	dbVersion := detectVersion(p)
+
+	// First deserialize the old database
+	db, err := deserializationFunctions[dbVersion](p)
+	if err != nil {
+		return err
+	}
+
+	// Now, migrate the database struct
+	for _, m := range migrationFunctions[dbVersion:] {
+		if m == nil {
+			continue
+		}
+
+		db, err = m(db)
+		if err != nil {
+			return err
+		}
+	}
+
+	// We must have a Database struct at the end of the migration
+	modernDB, ok := db.(*Database)
+	if !ok {
+		return errors.New("expected a Database at the end of migration")
+	}
+
+	// Serialize the migrated DB to disk
+	err = modernDB.serializeInternal()
+	if err != nil {
+		return err
+	}
+
+	// Now, perform cleanup
+	cleanup := cleanupFunctions[dbVersion]
+	if cleanup != nil {
+		err = cleanup(p)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/database/migration.go
+++ b/pkg/database/migration.go
@@ -80,7 +80,7 @@ func migrateV1ToV2(db any) (any, error) {
 	}
 
 	to := Database{
-		Version:     uint32(from.Version),
+		Version:     2,
 		Segments:    from.Segments,
 		Current:     uint32(from.Current),
 		TopicLookup: from.TopicLookup,

--- a/pkg/database/stats.go
+++ b/pkg/database/stats.go
@@ -1,12 +1,16 @@
 /*
- * Copyright (c) 2022, Gideon Williams gideon@gideonw.com
+ * Copyright (c) 2022, Gideon Williams <gideon@gideonw.com>
+ * Copyright (c) 2022, Dana Burkart <dana.burkart@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 package database
 
+import "time"
+
 type Stats struct {
-	Segments   int
-	TopicCount int
+	Segments      int
+	TopicCount    int
+	SerializeTime time.Time
 }


### PR DESCRIPTION
Previously, we wrote a gobb'd version of the database to disk. This changes that so we now write the following files to our database directory:

  * metadata
  * topics
  * segments/{0..N}

The metadata file now holds metadata about our database, including it's version, the number of segments, the current segment, and the last serialize time (recorded in the struct as STime).

The topics file contains a serialized list of topics, in index-order.

A new segments directory contains one file per segment, which allows us to write out only the most recent segment(s), instead of needing to write out the entire in-memory database.

closes #18