### PR TITLE
Remainder of database support for schemas

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -18,7 +18,7 @@ The complete list of types are:
 * int8, int16, int32, int64
 * float
 * array
-* shallow map
+* composite
 
 When creating a new topic, clients can choose to set a schema on the topic describing the kind of data expected to be
 stored. All datum which do not conform to the schema will be rejected on append.
@@ -29,10 +29,10 @@ Some interesting notes on data types:
   The difference is semantic; clients can choose to interpret the data differently depending on the type.
   For example, the fossil client will not display any data of type `binary`, since it could contain unprintable
   characters which have the potential to mess up a terminal.
-* Arrays can only hold one type of data, and the data can only be fixed. `string`, `binary`, and `shallow map`
+* Arrays can only hold one type of data, and the data can only be fixed. `string`, `binary`, and `composite`
   are all variable length, so cannot be held in an array. Additionally, array length must be declared as part of
   the upfront schema.
-* A shallow map is a constrained map which can contain any data type except a shallow map.
+* A composite is a combination of types that can be anything except a composite.
 
 ## Default Schema
 
@@ -70,7 +70,7 @@ For string, boolean, int*, float, and array, they are simply defined as the name
 | float    | float                     |
 | array    | `[size]<fixed-type>`      |
 
-A shallow map has a syntax similar to a JSON object, except that values are types:
+A composite type has a syntax similar to a JSON object, except that values are types:
 
 ```
 {
@@ -94,10 +94,10 @@ fixed-type  = "boolean" / "int8" / "int16" / "int32" / "int64" /
               "uint8" / "uint16" / "uint32" / "uint64" / "float32" / "float64"
 array       = "[" 1*DIGIT "]" fixed-type
 
-shallow-map = "{" map-entries "}"
-map-entries = 1*map-entry
-map-entry   = key ":" map-value ","
-map-value   = type / array
+composite   = "{" entries "}"
+entries     = 1*entry
+entry       = key ":" value ","
+value       = type / array
 
 key         = DQUOTE 1*( ALPHA / DIGIT / "_" / "-" ) DQUOTE
 ```

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -415,6 +415,13 @@ func (d *Database) Append(data []byte, topic string) {
 	e := Datum{Data: make([]byte, len(data)), TopicID: topicID}
 	copy(e.Data, data)
 
+	s := d.SchemaLookup[topicID]
+	if !s.Validate(data) {
+		// FIXME: We should either return an error, or move the data to a special topic
+		//        when this happens.
+		d.log.Error().Msg("Attempted to append non-validating data to a topic")
+	}
+
 	d.writeLock.Lock()
 	defer d.writeLock.Unlock()
 

--- a/pkg/database/log.go
+++ b/pkg/database/log.go
@@ -73,7 +73,12 @@ func (w *WriteAheadLog) ApplyToDB(d *Database) {
 			if err != nil {
 				log.Fatal(err)
 			}
-			d.addTopicInternal(topic)
+			pieces := strings.Split(topic, ":")
+			if len(pieces) == 1 {
+				d.addTopicInternal(topic, "string")
+			} else {
+				d.addTopicInternal(pieces[0], pieces[1])
+			}
 		}
 	}
 }
@@ -120,11 +125,11 @@ func (w *WriteAheadLog) AddSegment(t time.Time) {
 	}
 }
 
-func (w *WriteAheadLog) AddTopic(t string) {
+func (w *WriteAheadLog) AddTopic(t string, s string) {
 	var encoded bytes.Buffer
 
 	enc := gob.NewEncoder(&encoded)
-	err := enc.Encode(t)
+	err := enc.Encode(fmt.Sprintf("%s:%s", t, s))
 	if err != nil {
 		log.Fatal("encode:", err)
 	}

--- a/pkg/database/migration.go
+++ b/pkg/database/migration.go
@@ -90,6 +90,11 @@ func migrateV1ToV2(db any) (any, error) {
 		Name:        from.Name,
 	}
 
+	defaultSchema := to.loadSchema("string")
+	for range to.TopicLookup {
+		to.SchemaLookup = append(to.SchemaLookup, defaultSchema)
+	}
+
 	return &to, nil
 }
 

--- a/pkg/schema/objects.go
+++ b/pkg/schema/objects.go
@@ -22,7 +22,7 @@ type (
 		Type   Type
 	}
 
-	ShallowMap struct {
+	Composite struct {
 		Keys   []string
 		Values []Object
 	}
@@ -106,10 +106,10 @@ func (a Array) Validate(val []byte) bool {
 	return true
 }
 
-func (m ShallowMap) Validate(val []byte) bool {
+func (c Composite) Validate(val []byte) bool {
 	var size int
 	hasString := false
-	for _, val := range m.Values {
+	for _, val := range c.Values {
 		switch val.(type) {
 		case Type:
 			if val.(Type).Name == "string" {

--- a/pkg/schema/objects.go
+++ b/pkg/schema/objects.go
@@ -10,6 +10,7 @@ import "fmt"
 
 type Object interface {
 	Validate([]byte) bool
+	ToSchema() string
 }
 
 type (
@@ -87,6 +88,10 @@ func (t Type) Validate(val []byte) bool {
 	return true
 }
 
+func (t Type) ToSchema() string {
+	return t.Name
+}
+
 func (a Array) Size() int {
 	return a.Length * a.Type.Size()
 }
@@ -104,6 +109,10 @@ func (a Array) Validate(val []byte) bool {
 	}
 
 	return true
+}
+
+func (a Array) ToSchema() string {
+	return fmt.Sprintf("[%d]%s", a.Length, a.Type.ToSchema())
 }
 
 func (c Composite) Validate(val []byte) bool {
@@ -128,4 +137,20 @@ func (c Composite) Validate(val []byte) bool {
 		return len(val) >= size
 	}
 	return len(val) == size
+}
+
+func (c Composite) ToSchema() string {
+	var schema string
+
+	schema += "{"
+
+	for idx := range c.Keys {
+		key := c.Keys[idx]
+		val := c.Values[idx].ToSchema()
+
+		schema += fmt.Sprintf(`"%s":%s,`, key, val)
+	}
+
+	schema += "}"
+	return schema
 }

--- a/pkg/schema/objects.go
+++ b/pkg/schema/objects.go
@@ -29,6 +29,10 @@ type (
 	}
 )
 
+func (t Type) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, t.ToSchema())), nil
+}
+
 func (t Type) Size() int {
 	switch {
 	case t.Name == "boolean":
@@ -92,6 +96,10 @@ func (t Type) ToSchema() string {
 	return t.Name
 }
 
+func (a Array) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, a.ToSchema())), nil
+}
+
 func (a Array) Size() int {
 	return a.Length * a.Type.Size()
 }
@@ -113,6 +121,10 @@ func (a Array) Validate(val []byte) bool {
 
 func (a Array) ToSchema() string {
 	return fmt.Sprintf("[%d]%s", a.Length, a.Type.ToSchema())
+}
+
+func (c Composite) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, c.ToSchema())), nil
 }
 
 func (c Composite) Validate(val []byte) bool {
@@ -148,7 +160,7 @@ func (c Composite) ToSchema() string {
 		key := c.Keys[idx]
 		val := c.Values[idx].ToSchema()
 
-		schema += fmt.Sprintf(`"%s":%s,`, key, val)
+		schema += fmt.Sprintf(`'%s':%s,`, key, val)
 	}
 
 	schema += "}"

--- a/pkg/schema/objects_test.go
+++ b/pkg/schema/objects_test.go
@@ -8,6 +8,7 @@ package schema
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"testing"
 )
 
@@ -32,6 +33,21 @@ func TestArray_Validate(t *testing.T) {
 
 	b := make([]byte, 40)
 	if !tt.Validate(b) {
+		t.Fail()
+	}
+}
+
+func TestJSONMarshal(t *testing.T) {
+	ta := Array{Type: Type{Name: "int32"}, Length: 10}
+
+	b, _ := json.Marshal(ta)
+	if string(b) != `"[10]int32"` {
+		t.Fail()
+	}
+
+	tc := Composite{Keys: []string{"x", "y"}, Values: []Object{Type{Name: "int32"}, Type{Name: "int32"}}}
+	b, _ = json.Marshal(tc)
+	if string(b) != `"{'x':int32,'y':int32,}"` {
 		t.Fail()
 	}
 }

--- a/pkg/schema/parser.go
+++ b/pkg/schema/parser.go
@@ -60,7 +60,7 @@ func (p *Parser) schema() Object {
 		return schema
 	}
 
-	if schema = p.shallowMap(); schema != nil {
+	if schema = p.composite(); schema != nil {
 		return schema
 	}
 
@@ -121,8 +121,8 @@ func (p *Parser) array() Object {
 	return &array
 }
 
-func (p *Parser) shallowMap() Object {
-	var sMap ShallowMap
+func (p *Parser) composite() Object {
+	var composite Composite
 
 	tok := p.Scanner.Emit()
 	if tok.Type != TOK_CURLY_O {
@@ -138,7 +138,7 @@ func (p *Parser) shallowMap() Object {
 			panic(parse.NewSyntaxError(tok, fmt.Sprintf("Error: unexpected token '%s', expected a map key (\"...\")", tok.Lexeme)))
 		}
 
-		sMap.Keys = append(sMap.Keys, tok.Lexeme)
+		composite.Keys = append(composite.Keys, tok.Lexeme)
 
 		tok = p.Scanner.Emit()
 		if tok.Type != TOK_COLON {
@@ -156,7 +156,7 @@ func (p *Parser) shallowMap() Object {
 			}
 		}
 
-		sMap.Values = append(sMap.Values, val)
+		composite.Values = append(composite.Values, val)
 
 		// Finally, every line must have a comma
 		tok = p.Scanner.Emit()
@@ -168,5 +168,5 @@ func (p *Parser) shallowMap() Object {
 		tok = p.Scanner.Emit()
 	}
 
-	return &sMap
+	return &composite
 }

--- a/pkg/schema/parser.go
+++ b/pkg/schema/parser.go
@@ -14,6 +14,11 @@ import (
 	"strings"
 )
 
+func Parse(s string) (Object, error) {
+	p := Parser{Scanner{Input: s}}
+	return p.Parse()
+}
+
 type Parser struct {
 	Scanner Scanner
 }

--- a/pkg/schema/parser_test.go
+++ b/pkg/schema/parser_test.go
@@ -125,7 +125,7 @@ func TestParseShallowMap(t *testing.T) {
 		t.Fail()
 	}
 
-	if _, ok := obj.(*ShallowMap); !ok {
+	if _, ok := obj.(*Composite); !ok {
 		t.Fail()
 	}
 
@@ -140,7 +140,7 @@ func TestParseShallowMap(t *testing.T) {
 		t.Fail()
 	}
 
-	if _, ok := obj.(*ShallowMap); !ok {
+	if _, ok := obj.(*Composite); !ok {
 		t.Fail()
 	}
 

--- a/pkg/schema/parser_test.go
+++ b/pkg/schema/parser_test.go
@@ -57,7 +57,7 @@ func TestParseType(t *testing.T) {
 
 	p = Parser{
 		Scanner{
-			Input: "float",
+			Input: "float32",
 		},
 	}
 

--- a/pkg/schema/scanner.go
+++ b/pkg/schema/scanner.go
@@ -30,14 +30,16 @@ func (s *Scanner) MatchKey() int {
 	pos := s.Pos
 	r, width := utf8.DecodeRuneInString(s.Input[pos:])
 
-	if r != '"' {
+	if r != '"' && r != '\'' {
 		return 0
 	}
+
+	matchRune := r
 
 	pos += width
 	r, width = utf8.DecodeRuneInString(s.Input[pos:])
 
-	for r != '"' {
+	for r != matchRune {
 		if pos >= len(s.Input) {
 			return 0
 		}
@@ -110,7 +112,7 @@ func (s *Scanner) Emit() parse.Token {
 				skip = s.SkipToBoundary(isDelimiter)
 			}
 			t.Type = TOK_NUMBER
-		case r == '"':
+		case r == '"' || r == '\'':
 			skip = s.MatchKey()
 			if skip == 0 {
 				t.Type = TOK_INVALID

--- a/pkg/schema/scanner.go
+++ b/pkg/schema/scanner.go
@@ -132,9 +132,12 @@ func (s *Scanner) Emit() parse.Token {
 			skip = s.SkipToBoundary(isDelimiter)
 		case r == 'f':
 			if strings.HasPrefix(s.Input[s.Pos:], "float") {
-				t.Type = TOK_TYPE
-				skip = len("float")
-				break
+				if strings.HasPrefix(s.Input[s.Pos+5:], "32") ||
+					strings.HasPrefix(s.Input[s.Pos+5:], "64") {
+					t.Type = TOK_TYPE
+					skip = len("float32")
+					break
+				}
 			}
 			t.Type = TOK_INVALID
 			skip = s.SkipToBoundary(isDelimiter)

--- a/pkg/schema/scanner_test.go
+++ b/pkg/schema/scanner_test.go
@@ -45,6 +45,14 @@ func TestScannerMatchKey(t *testing.T) {
 	if n != 0 {
 		t.Fail()
 	}
+
+	s = Scanner{
+		Input: "'barbaz'",
+	}
+	n = s.MatchKey()
+	if n != len(s.Input) {
+		t.Fail()
+	}
 }
 
 func TestScannerTypes(t *testing.T) {

--- a/pkg/schema/scanner_test.go
+++ b/pkg/schema/scanner_test.go
@@ -48,9 +48,9 @@ func TestScannerMatchKey(t *testing.T) {
 }
 
 func TestScannerTypes(t *testing.T) {
-	s := Scanner{Input: "boolean int8 int16 int32 int64 string float"}
+	s := Scanner{Input: "boolean int8 int16 int32 int64 string float32 float64"}
 
-	expectedKeywordLexemes := []string{"boolean", "int8", "int16", "int32", "int64", "string", "float"}
+	expectedKeywordLexemes := []string{"boolean", "int8", "int16", "int32", "int64", "string", "float32", "float64"}
 
 	for i := 0; i < len(expectedKeywordLexemes); i++ {
 		tok := s.Emit()


### PR DESCRIPTION
This PR covers these changes:

 * Rename "shallow map" to "composite", since it's really just a composite type
 * Teach schema.Object how to marshal itself as JSON
 * The database now tracks what schema a given topic has, and defaults it to "string"

This closes #17, but we still have to support topic creation (with ability to specify a schema) in #108.