### PR TITLE
Teach the server and client how to create new topics and schemas

### DIFF
--- a/cmd/fossil/client/client.go
+++ b/cmd/fossil/client/client.go
@@ -168,7 +168,7 @@ func formatDataForTopic(entry database.Entry) string {
 	case schemaName == "string":
 		output = string(data)
 	case schemaName == "binary":
-		output = "binary(...binary data...)"
+		output = fmt.Sprintf("binary(...%d bytes...)", len(data))
 	case schemaName == "boolean":
 		b := "true"
 		if data[0] == 0 {

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -500,9 +500,10 @@ func (d *Database) entriesFromData(s *Segment, data []Datum) []Entry {
 
 	for index, val := range data {
 		entries[index] = Entry{
-			Time:  s.HeadTime.Add(val.Delta),
-			Topic: d.TopicLookup[val.TopicID],
-			Data:  val.Data,
+			Time:   s.HeadTime.Add(val.Delta),
+			Topic:  d.TopicLookup[val.TopicID],
+			Schema: d.SchemaLookup[val.TopicID].ToSchema(),
+			Data:   val.Data,
 		}
 	}
 

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -76,7 +76,7 @@ func normalizeTopicName(topicName string) string {
 		topicName = "/" + topicName
 	}
 
-	if topicName[len(topicName)-1] == '/' {
+	if len(topicName) > 1 && topicName[len(topicName)-1] == '/' {
 		topicName = topicName[:len(topicName)-1]
 	}
 

--- a/pkg/database/result.go
+++ b/pkg/database/result.go
@@ -7,6 +7,7 @@
 package database
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -21,13 +22,14 @@ type Result struct {
 // An Entry is a hydrated Datum, where the time and topic have been
 // expanded.
 type Entry struct {
-	Time  time.Time
-	Topic string
-	Data  []byte
+	Time   time.Time
+	Topic  string
+	Schema string
+	Data   []byte
 }
 
 func (e *Entry) ToString() string {
-	return fmt.Sprintf("%s\t%s\t%s", e.Time.Format(time.RFC3339Nano), e.Topic, string(e.Data))
+	return fmt.Sprintf("%s\t%s\t%s\t%s", e.Time.Format(time.RFC3339Nano), e.Topic, base64.StdEncoding.EncodeToString(e.Data), e.Schema)
 }
 
 func ParseEntry(s string) (Entry, error) {
@@ -42,7 +44,8 @@ func ParseEntry(s string) (Entry, error) {
 	}
 	ent.Time = t
 	ent.Topic = parts[1]
-	ent.Data = []byte(parts[2])
+	ent.Data, err = base64.StdEncoding.DecodeString(parts[2])
+	ent.Schema = parts[3]
 	return ent, nil
 }
 

--- a/pkg/proto/command.go
+++ b/pkg/proto/command.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Gideon Williams gideon@gideonw.com
+ * Copyright (c) 2022, Gideon Williams <gideon@gideonw.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -23,4 +23,6 @@ var (
 	CommandQuery = "QUERY"
 	// CommandAppend appends data to the current database
 	CommandAppend = "APPEND"
+	// CommandCreate is used to create topics (but could be used for other purposes in the future)
+	CommandCreate = "CREATE"
 )

--- a/pkg/proto/message.go
+++ b/pkg/proto/message.go
@@ -601,6 +601,7 @@ func (rq *CreateTopicRequest) Unmarshal(b []byte) error {
 	if err != nil {
 		return err
 	}
+	rq.Topic = string(topic)
 	rq.Schema = string(b[n+m:])
 	if rq.Schema == "" {
 		rq.Schema = "string"

--- a/pkg/proto/message_test.go
+++ b/pkg/proto/message_test.go
@@ -323,3 +323,22 @@ func TestListResponse(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestCreateTopicRequest(t *testing.T) {
+	req := CreateTopicRequest{Topic: "/foo/bar", Schema: "int32"}
+
+	b, _ := req.Marshal()
+	err := req.Unmarshal(b)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	if req.Topic != "/foo/bar" {
+		t.Fail()
+	}
+
+	if req.Schema != "int32" {
+		t.Fail()
+	}
+}

--- a/pkg/proto/message_test.go
+++ b/pkg/proto/message_test.go
@@ -341,4 +341,21 @@ func TestCreateTopicRequest(t *testing.T) {
 	if req.Schema != "int32" {
 		t.Fail()
 	}
+
+	req = CreateTopicRequest{Topic: "/foo/bar", Schema: ""}
+
+	b, _ = req.Marshal()
+	err = req.Unmarshal(b)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	if req.Topic != "/foo/bar" {
+		t.Fail()
+	}
+
+	if req.Schema != "string" {
+		t.Fail()
+	}
 }

--- a/pkg/repl/parser.go
+++ b/pkg/repl/parser.go
@@ -79,6 +79,27 @@ func ParseREPLCommand(b []byte) (proto.Message, error) {
 		req.Object = string(data)
 
 		msg = proto.NewMessageWithType(proto.CommandList, req)
+	case proto.CommandCreate:
+		req := proto.CreateTopicRequest{}
+
+		if !strings.HasPrefix(string(data), "topic") &&
+			!strings.HasPrefix(string(data), "TOPIC") {
+			return nil, errors.New("malformed create request: expected topic keyword after create")
+		}
+
+		begin := bytes.IndexByte(data, ' ') + 1
+		spaceInd := bytes.IndexByte(data[begin:], ' ') + begin
+
+		// No schema
+		if spaceInd == -1 {
+			req.Topic = string(data[begin:])
+			req.Schema = ""
+		} else {
+			req.Topic = string(data[begin:spaceInd])
+			req.Schema = string(data[spaceInd+1:])
+		}
+
+		msg = proto.NewMessageWithType(proto.CommandCreate, req)
 	default:
 		msg = proto.NewMessage(command, b)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -221,6 +221,15 @@ func (s *Server) HandleList(rw proto.ResponseWriter, r *proto.Request) {
 		for _, v := range r.Database().TopicLookup {
 			resp.ObjectList = append(resp.ObjectList, v)
 		}
+	} else if l.Object == "schemas" {
+		// Get our string object
+		str := r.Database().SchemaLookup[0]
+		for idx, v := range r.Database().TopicLookup {
+			schema := r.Database().SchemaLookup[idx]
+			if schema != str {
+				resp.ObjectList = append(resp.ObjectList, fmt.Sprintf("%s %s", v, schema.ToSchema()))
+			}
+		}
 	}
 
 	rw.WriteMessage(proto.NewMessageWithType(proto.CommandList, resp))


### PR DESCRIPTION
This PR includes the following:

* Logic in the protocol for creating new topics (and their associated schemas)
* A new "create topic" command in the REPL
* Plumbs logic through database internals for validating new schemas against existing topic hierarchies.

closes #108 