### PR TITLE
Use url.Parse() to parse fossil urls.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 Dana Burkart <dana.burkart@gmail.com>
+Copyright 2022-2023 Dana Burkart <dana.burkart@gmail.com>
 Copyright 2022 Gideon Williams <gideon@gideonw.com>
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For documentation on deploying Fossil, see [deployment.md](./docs/deployment.md)
 port = 8000
 prom-port = 2112
 
-host = "fossil://local/default"
+host = "fossil://localhost:8001/default"
 local = true
 verbose = 2
 
@@ -118,13 +118,13 @@ directory = "./data"
 ```
 
 #### Root `fossil` config block
-| Option             | Default                    | Description                                            |
-| ------------------ | -------------------------- | ------------------------------------------------------ |
-| `fossil.port`      | 8001                       | Port fossil server listens on                          |
-| `fossil.prom-port` | 2112                       | Port fossil server servers `/metrics` on               |
-| `fossil.verbose`   | 0                          | Configures the log level [0: info, 1: debug, 2: trace] |
-| `fossil.host`      | `"fossil://local/default"` | Connection string client will connect to               |
-| `fossil.local`     | true                       | Configures output logs to be in plaintext              |
+| Option             | Default       | Description                                            |
+| ------------------ |---------------| ------------------------------------------------------ |
+| `fossil.port`      | 8001          | Port fossil server listens on                          |
+| `fossil.prom-port` | 2112          | Port fossil server servers `/metrics` on               |
+| `fossil.verbose`   | 0             | Configures the log level [0: info, 1: debug, 2: trace] |
+| `fossil.host`      | `"./default"` | Connection string client will connect to               |
+| `fossil.local`     | true          | Configures output logs to be in plaintext              |
 
 ####  `database` config block
 The first database block without a `.<name>` applies to the `default` database. 

--- a/api/api.go
+++ b/api/api.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Dana Burkart <dana.burkart@gmail.com>
+ * Copyright (c) 2022-2023, Dana Burkart <dana.burkart@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -41,8 +41,13 @@ func NewClient(connstr string) (Client, error) {
 // volumes of data to fossil.
 func NewClientPool(connstr string, size uint) (Client, error) {
 	var client Client
+	var err error
 
-	client.target = proto.ParseConnectionString(connstr)
+	client.target, err = proto.ParseConnectionString(connstr)
+	if err != nil {
+		return Client{}, err
+	}
+
 	client.conn = make(chan net.Conn, size)
 
 	for i := uint(0); i < size; i++ {

--- a/cmd/fossil/client/client.go
+++ b/cmd/fossil/client/client.go
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Gideon Williams <gideon@gideonw.com>
- * Copyright (c) 2022, Dana Burkart <dana.burkart@gmail.com>
+ * Copyright (c) 2022-2023, Dana Burkart <dana.burkart@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -39,7 +39,10 @@ var (
 			log := viper.Get("logger").(zerolog.Logger)
 
 			host := viper.GetString("fossil.host")
-			target := proto.ParseConnectionString(host)
+			target, err := proto.ParseConnectionString(host)
+			if err != nil {
+				log.Fatal().Err(err).Msg("error parsing URL")
+			}
 
 			if target.Local {
 				db, err := database.NewDatabase(log, target.Database, target.Database)

--- a/cmd/fossil/root.go
+++ b/cmd/fossil/root.go
@@ -31,7 +31,7 @@ func init() {
 	// Configure the root binary options
 	rootCmd.PersistentFlags().CountP("verbose", "v", "-v for debug logs (-vv for trace)")
 	rootCmd.PersistentFlags().Bool("local", true, "Configures the logger to print readable logs") //TODO: true until we have a config file format
-	rootCmd.PersistentFlags().StringP("host", "H", "fossil://local/default", "Host to send the messages")
+	rootCmd.PersistentFlags().StringP("host", "H", "./default", "Host to send the messages")
 	rootCmd.PersistentFlags().StringP("config", "c", "", "Path to the fossil config file (default ./config.toml)")
 
 	// Bind viper config to the root flags

--- a/config.default.toml
+++ b/config.default.toml
@@ -2,7 +2,7 @@
 port = 8001
 prom-port = 2112
 
-host = "fossil://local/default"
+host = "fossil://localhost:8001/default"
 local = true
 verbose = 2
 

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Dana Burkart <dana.burkart@gmail.com>
+ * Copyright (c) 2022-2023, Dana Burkart <dana.burkart@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -574,12 +574,10 @@ func (d *Database) Retrieve(q Query) []Entry {
 func NewDatabase(log zerolog.Logger, name string, location string) (*Database, error) {
 	var db Database
 
-	directory := filepath.Join(location, name)
-
 	// If the path does not exist, create a new directory
-	fileinfo, err := os.Stat(directory)
+	fileinfo, err := os.Stat(location)
 	if os.IsNotExist(err) {
-		err := os.Mkdir(directory, 0700)
+		err := os.Mkdir(location, 0700)
 		if err != nil {
 			return nil, err
 		}
@@ -588,14 +586,14 @@ func NewDatabase(log zerolog.Logger, name string, location string) (*Database, e
 	}
 
 	// Migrate the database if it's old
-	err = MigrateDatabaseIfNeeded(directory)
+	err = MigrateDatabaseIfNeeded(location)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err = os.Stat(filepath.Join(directory, "metadata")); err == nil {
+	if _, err = os.Stat(filepath.Join(location, "metadata")); err == nil {
 		db = Database{
-			Path: directory,
+			Path: location,
 		}
 		err = db.deserializeInternal()
 		if err != nil {
@@ -604,10 +602,10 @@ func NewDatabase(log zerolog.Logger, name string, location string) (*Database, e
 		db.topics = make(map[string]int)
 		wal := WriteAheadLog{filepath.Join(db.Path, "wal.log")}
 		wal.ApplyToDB(&db)
-	} else if _, err = os.Stat(filepath.Join(directory, "wal.log")); err == nil {
+	} else if _, err = os.Stat(filepath.Join(location, "wal.log")); err == nil {
 		db = Database{
 			Version:    FossilDBVersion,
-			Path:       directory,
+			Path:       location,
 			Segments:   []Segment{},
 			Current:    0,
 			topics:     make(map[string]int),
@@ -618,7 +616,7 @@ func NewDatabase(log zerolog.Logger, name string, location string) (*Database, e
 	} else {
 		db = Database{
 			Version:    FossilDBVersion,
-			Path:       directory,
+			Path:       location,
 			Segments:   []Segment{},
 			Current:    0,
 			topics:     make(map[string]int),

--- a/pkg/proto/connectionstring_test.go
+++ b/pkg/proto/connectionstring_test.go
@@ -21,21 +21,21 @@ func TestParseConnectionString(t *testing.T) {
 			"",
 			"local",
 			true,
-			"default",
+			"./",
 		},
 		{
 			"Test local no db",
-			"fossil://local",
+			"file:///local",
 			"local",
 			true,
-			"default",
+			"/local",
 		},
 		{
-			"Test local db",
-			"fossil://local/db1",
+			"Test local db no scheme",
+			"./local/db1",
 			"local",
 			true,
-			"db1",
+			"./local/db1",
 		},
 		{
 			"Test host no db end slash",
@@ -49,34 +49,33 @@ func TestParseConnectionString(t *testing.T) {
 			"local",
 			"local",
 			true,
-			"default",
+			"local",
 		},
 		{
 			"Test no proto local path db",
-			"local/data/db.log",
+			"./data/default",
 			"local",
 			true,
-			"data/db.log",
-		},
-		{
-			"Test no proto local no db",
-			"localhost/",
-			"localhost",
-			false,
-			"default",
+			"./data/default",
 		},
 	}
 
-	shouldPanic(t, func(t *testing.T) {
-		ParseConnectionString("fosssil:///zx")
-	})
-	shouldPanic(t, func(t *testing.T) {
-		ParseConnectionString("tcp:///zx")
-	})
+	_, err := ParseConnectionString("fosssil:///zx")
+	if err == nil {
+		t.Error("fosssil:///zx should have caused an error")
+	}
+
+	_, err = ParseConnectionString("tcp:///zx")
+	if err == nil {
+		t.Error("tcp:///zx should have caused an error")
+	}
 
 	for _, tc := range tt {
 		t.Run(tc.test, func(t *testing.T) {
-			connStr := ParseConnectionString(tc.connStr)
+			connStr, err := ParseConnectionString(tc.connStr)
+			if err != nil {
+				t.Error(err)
+			}
 			recover()
 			if connStr.Address != tc.addr {
 				t.Errorf("Address mismatch: %s != %s", connStr.Address, tc.addr)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -9,6 +9,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"path"
 	"runtime"
 	"time"
 
@@ -45,7 +46,7 @@ func New(log zerolog.Logger, dbConfigs map[string]DatabaseConfig, port, metricsP
 	for k, v := range dbConfigs {
 		log.Info().Str("name", v.Name).Str("directory", v.Directory).Msg("initializing database")
 		dbLogger := log.With().Str("db", v.Name).Logger()
-		db, err := database.NewDatabase(dbLogger, v.Name, v.Directory)
+		db, err := database.NewDatabase(dbLogger, v.Name, path.Join(v.Directory, v.Name))
 		if err != nil {
 			dbLogger.Fatal().Err(err).Msg("error initializing database")
 		}


### PR DESCRIPTION
Instead of rolling our own URL parsing, use url.Parse(). In addition,
this patch changes some of the URL behavior:

  * We now support file:// protocol
  * Gone is the "local" specifier, i.e. fossil://local/foo or local/foo.
    Instead, users can either write ./path/to/foo or file://./path/to/foo
  * CreateDatabase() now expects the "location" argument to fully
    resolve to the database in question. Previously, it would slap
    together the location and the name. Internally, the database name is
    not used, so it doesn't make sense to have that logic live in
    CreateDatabase.