### PR TITLE
Support for appending structured data in the client

### DIFF
--- a/api/encode.go
+++ b/api/encode.go
@@ -16,10 +16,15 @@ import (
 	"strings"
 )
 
-func EncodeType(v any) ([]byte, error) {
+type SchemaType interface {
+	[]byte | bool | string | int16 | int32 | int64 | uint16 |
+		uint32 | uint64 | float32 | float64
+}
+
+func EncodeType[T SchemaType](v T) ([]byte, error) {
 	var formatted []byte
 
-	switch t := v.(type) {
+	switch t := any(v).(type) {
 	case []byte:
 		return t, nil
 	case bool:
@@ -50,7 +55,7 @@ func EncodeType(v any) ([]byte, error) {
 		return binary.LittleEndian.AppendUint64(formatted, math.Float64bits(t)), nil
 	}
 
-	return nil, errors.New("unrecognized type")
+	panic("We should not get here")
 }
 
 func DecodeStringForSchema(input []byte, s schema.Object) (string, error) {

--- a/api/encode.go
+++ b/api/encode.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2023, Dana Burkart <dana.burkart@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+package fossil
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"github.com/dburkart/fossil/pkg/schema"
+	"math"
+	"strconv"
+	"strings"
+)
+
+func EncodeType(v any) ([]byte, error) {
+	var formatted []byte
+
+	switch t := v.(type) {
+	case []byte:
+		return t, nil
+	case bool:
+		var b uint8
+		b = 0
+		if t {
+			b = 1
+		}
+		formatted = append(formatted, b)
+		return formatted, nil
+	case string:
+		return []byte(t), nil
+	case int16:
+		return binary.LittleEndian.AppendUint16(formatted, uint16(t)), nil
+	case int32:
+		return binary.LittleEndian.AppendUint32(formatted, uint32(t)), nil
+	case int64:
+		return binary.LittleEndian.AppendUint64(formatted, uint64(t)), nil
+	case uint16:
+		return binary.LittleEndian.AppendUint16(formatted, t), nil
+	case uint32:
+		return binary.LittleEndian.AppendUint32(formatted, t), nil
+	case uint64:
+		return binary.LittleEndian.AppendUint64(formatted, t), nil
+	case float32:
+		return binary.LittleEndian.AppendUint32(formatted, math.Float32bits(t)), nil
+	case float64:
+		return binary.LittleEndian.AppendUint64(formatted, math.Float64bits(t)), nil
+	}
+
+	return nil, errors.New("unrecognized type")
+}
+
+// EncodeStringForSchema takes an input string and a schema.Object, and returns
+// a byte slice representing that string.
+func EncodeStringForSchema(input string, s schema.Object) ([]byte, error) {
+	var formatted []byte
+
+	switch t := s.(type) {
+	case *schema.Type:
+		switch t.Name {
+		case "string":
+			return []byte(input), nil
+		case "boolean":
+			var b uint8
+			b = 1
+			if input == "false" {
+				b = 0
+			}
+			formatted = append(formatted, b)
+			return formatted, nil
+		case "int16":
+			i, err := strconv.ParseInt(input, 10, 16)
+			if err != nil {
+				return nil, err
+			}
+			return EncodeType(int16(i))
+		case "int32":
+			i, err := strconv.ParseInt(input, 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			return EncodeType(int32(i))
+		case "int64":
+			i, err := strconv.ParseInt(input, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			return EncodeType(i)
+		case "uint16":
+			i, err := strconv.ParseUint(input, 10, 16)
+			if err != nil {
+				return nil, err
+			}
+			return EncodeType(uint16(i))
+		case "uint32":
+			i, err := strconv.ParseUint(input, 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			return EncodeType(uint32(i))
+		case "uint64":
+			i, err := strconv.ParseUint(input, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			return EncodeType(i)
+		case "float32":
+			f, err := strconv.ParseFloat(input, 32)
+			if err != nil {
+				return nil, err
+			}
+			return EncodeType(float32(f))
+		case "float64":
+			f, err := strconv.ParseFloat(input, 64)
+			if err != nil {
+				return nil, err
+			}
+			return EncodeType(f)
+		}
+	case *schema.Array:
+		var array []string
+		array = strings.Split(input, ",")
+		// Basic bounds checking
+		if len(array) != t.Length {
+			return nil, errors.New(fmt.Sprintf("schema expects %d elements, you provided %d", t.Length, len(array)))
+		}
+		// For each value in the array, pack it into formatted
+		for _, v := range array {
+			b, err := EncodeStringForSchema(strings.Trim(v, " \t"), &t.Type)
+			if err != nil {
+				return nil, err
+			}
+			formatted = append(formatted, b...)
+		}
+
+		return formatted, nil
+	case *schema.Composite:
+		// FIXME: Implement
+	}
+
+	return formatted, nil
+}

--- a/api/encode.go
+++ b/api/encode.go
@@ -123,6 +123,8 @@ func EncodeStringForSchema(input string, s schema.Object) ([]byte, error) {
 		switch t.Name {
 		case "string":
 			return []byte(input), nil
+		case "binary":
+			return []byte(input), nil
 		case "boolean":
 			var b uint8
 			b = 1

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -40,7 +40,7 @@ unary           = ( "-" / "+" ) unary / primary
 primary         = identifier / number / string / tuple / builtin
 
 ; Built in functions
-builtin         = identifier "(" ( expression / tuple ) ")"
+builtin         = identifier "(" expression  ")"
 
 ; Data Types
 number          = 1*DIGIT

--- a/pkg/repl/parser_test.go
+++ b/pkg/repl/parser_test.go
@@ -8,6 +8,7 @@ package repl
 
 import (
 	"bytes"
+	"github.com/dburkart/fossil/pkg/schema"
 	"testing"
 
 	"github.com/dburkart/fossil/pkg/proto"
@@ -15,7 +16,7 @@ import (
 
 func TestParseREPLCommand(t *testing.T) {
 	t.Run("use", func(t *testing.T) {
-		msg, err := ParseREPLCommand([]byte("use default"))
+		msg, err := ParseREPLCommand([]byte("use default"), map[string]schema.Object{})
 		if err != nil {
 			t.Fail()
 		}
@@ -28,7 +29,7 @@ func TestParseREPLCommand(t *testing.T) {
 	})
 	t.Run("append no topic", func(t *testing.T) {
 		cmp := proto.NewMessageWithType(proto.CommandAppend, proto.AppendRequest{Topic: "", Data: []byte("a")})
-		msg, err := ParseREPLCommand([]byte("append a"))
+		msg, err := ParseREPLCommand([]byte("append a"), map[string]schema.Object{})
 		if err != nil {
 			t.Fail()
 		}
@@ -41,7 +42,7 @@ func TestParseREPLCommand(t *testing.T) {
 	})
 	t.Run("append", func(t *testing.T) {
 		cmp := proto.NewMessageWithType(proto.CommandAppend, proto.AppendRequest{Topic: "/", Data: []byte("a")})
-		msg, err := ParseREPLCommand([]byte("append / a"))
+		msg, err := ParseREPLCommand([]byte("append / a"), map[string]schema.Object{})
 		if err != nil {
 			t.Fail()
 		}
@@ -54,7 +55,7 @@ func TestParseREPLCommand(t *testing.T) {
 	})
 	t.Run("append missing slash", func(t *testing.T) {
 		cmp := proto.NewMessageWithType(proto.CommandAppend, proto.AppendRequest{Topic: "", Data: []byte("foo/bar/baz a")})
-		msg, err := ParseREPLCommand([]byte("append foo/bar/baz a"))
+		msg, err := ParseREPLCommand([]byte("append foo/bar/baz a"), map[string]schema.Object{})
 		if err != nil {
 			t.Fail()
 		}
@@ -66,14 +67,14 @@ func TestParseREPLCommand(t *testing.T) {
 		}
 	})
 	t.Run("append no args", func(t *testing.T) {
-		_, err := ParseREPLCommand([]byte("append"))
+		_, err := ParseREPLCommand([]byte("append"), map[string]schema.Object{})
 		if err == nil {
 			t.Fail()
 		}
 	})
 	t.Run("query no query", func(t *testing.T) {
 		cmp := proto.NewMessageWithType(proto.CommandQuery, proto.QueryRequest{Query: ""})
-		msg, err := ParseREPLCommand([]byte("query"))
+		msg, err := ParseREPLCommand([]byte("query"), map[string]schema.Object{})
 		if err != nil {
 			t.Fail()
 		}
@@ -86,7 +87,7 @@ func TestParseREPLCommand(t *testing.T) {
 	})
 	t.Run("query", func(t *testing.T) {
 		cmp := proto.NewMessageWithType(proto.CommandQuery, proto.QueryRequest{Query: "all"})
-		msg, err := ParseREPLCommand([]byte("query all"))
+		msg, err := ParseREPLCommand([]byte("query all"), map[string]schema.Object{})
 		if err != nil {
 			t.Fail()
 		}


### PR DESCRIPTION
This implements sending everything but composites. Demo:

```
> create topic /sensors/temp float32
200 Ok

> list schemas
/sensors/temp float32

> append /sensors/temp 55.6
200 Ok

> query all
+-------------------------------------+---------------+--------------------+
|                TIME                 |     TOPIC     |        DATA        |
+-------------------------------------+---------------+--------------------+
| 2023-01-03T13:09:25.218208875-08:00 | /sensors/temp | float32(55.599998) |
+-------------------------------------+---------------+--------------------+

> exit
```

and arrays:

```
> create topic /points [2]int32
200 Ok

> list schemas
/sensors/temp float32
/points [2]int32

> append /points 1000, 2000
200 Ok

> query all
+-------------------------------------+---------------+----------------------+
|                TIME                 |     TOPIC     |         DATA         |
+-------------------------------------+---------------+----------------------+
| 2023-01-03T13:09:25.218208875-08:00 | /sensors/temp | float32(55.599998)   |
| 2023-01-03T13:10:38.915201334-08:00 | /points       | [2]int32(1000, 2000) |
+-------------------------------------+---------------+----------------------+
```