### PR TITLE
Support tuple values in the pipeline backend

### DIFF
--- a/pkg/query/plan/function.go
+++ b/pkg/query/plan/function.go
@@ -57,8 +57,13 @@ func (f *Function) Visit(node ast.ASTNode) ast.Visitor {
 			f.results[n] = types.UnaryOp(n.Operator, f.results[n.Operand])
 		case *ast.BinaryOpNode:
 			f.results[n] = types.BinaryOp(f.results[n.Left], n.Op, f.results[n.Right])
+		case *ast.TupleNode:
+			var values []types.Value
+			for _, v := range n.Elements {
+				values = append(values, f.results[v])
+			}
+			f.results[n] = types.MakeTuple(values)
 		case *ast.DataFunctionNode:
-			// FIXME: Handle tuples
 			f.Result = append(f.Result, f.results[n.Expression])
 		}
 
@@ -66,7 +71,7 @@ func (f *Function) Visit(node ast.ASTNode) ast.Visitor {
 	}
 
 	switch n := node.(type) {
-	case *ast.DataFunctionNode, *ast.IdentifierNode, *ast.NumberNode, *ast.UnaryOpNode, *ast.BinaryOpNode:
+	case *ast.DataFunctionNode, *ast.IdentifierNode, *ast.NumberNode, *ast.UnaryOpNode, *ast.BinaryOpNode, *ast.TupleNode:
 		f.push(n)
 		return f
 	}

--- a/pkg/query/plan/pipeline.go
+++ b/pkg/query/plan/pipeline.go
@@ -123,7 +123,11 @@ func (w *WrappedEntry) Entry() database.Entry {
 	if w.val == nil {
 		return *w.entry
 	}
-	e := types.EntryFromValue(w.Value())
+	e, err := types.EntryFromValue(w.Value())
+	if err != nil {
+		e.Schema = "string"
+		e.Data = []byte("Invalid conversion to schema object.")
+	}
 	e.Time = w.entry.Time
 	e.Topic = w.entry.Topic
 	return e


### PR DESCRIPTION
This allows tuples to flow through a pipeline. For example, this kind of thing is now possible:

```
> query all x in /numbers : map x -> 1, x
+----------------------------------+----------+----------+-------+
|               TIME               |  TOPIC   |  SCHEMA  | DATA  |
+----------------------------------+----------+----------+-------+
| 2023-01-12T16:17:33.742625-08:00 | /numbers | [2]int64 | 1, 1  |
| 2023-01-12T16:17:35.52783-08:00  | /numbers | [2]int64 | 1, 2  |
| 2023-01-12T16:17:42.102728-08:00 | /numbers | [2]int64 | 1, 3  |
| 2023-01-12T16:17:43.302907-08:00 | /numbers | [2]int64 | 1, 4  |
| 2023-01-12T16:17:44.604381-08:00 | /numbers | [2]int64 | 1, 5  |
| 2023-01-12T16:17:45.751371-08:00 | /numbers | [2]int64 | 1, 6  |
| 2023-01-12T16:17:46.846735-08:00 | /numbers | [2]int64 | 1, 7  |
| 2023-01-12T16:17:48.286286-08:00 | /numbers | [2]int64 | 1, 8  |
| 2023-01-12T16:17:49.504595-08:00 | /numbers | [2]int64 | 1, 9  |
| 2023-01-12T16:17:52.687078-08:00 | /numbers | [2]int64 | 1, 10 |
+----------------------------------+----------+----------+-------+
```

Closes #136.
